### PR TITLE
Improved "last tab closing" behavior

### DIFF
--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -439,11 +439,7 @@ namespace Files.Interacts
         {
             if (((Window.Current.Content as Frame).Content as InstanceTabsView).TabStrip.TabItems.Count == 1)
             {
-                IList<AppDiagnosticInfo> infos = await AppDiagnosticInfo.RequestInfoForAppAsync();
-                IList<AppResourceGroupInfo> resourceInfos = infos[0].GetResourceGroups();
-                var pid = Windows.System.Diagnostics.ProcessDiagnosticInfo.GetForCurrentProcess().ProcessId;
-                await resourceInfos.Single(r => r.GetProcessDiagnosticInfos()[0].ProcessId == pid).StartTerminateAsync();
-                //Application.Current.Exit();
+                await InstanceTabsView.StartTerminateAsync();
             }
             else if (((Window.Current.Content as Frame).Content as InstanceTabsView).TabStrip.TabItems.Count > 1)
             {

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -435,11 +435,15 @@ namespace Files.Interacts
             }
         }
 
-        public void CloseTab()
+        public async void CloseTab()
         {
             if (((Window.Current.Content as Frame).Content as InstanceTabsView).TabStrip.TabItems.Count == 1)
             {
-                Application.Current.Exit();
+                IList<AppDiagnosticInfo> infos = await AppDiagnosticInfo.RequestInfoForAppAsync();
+                IList<AppResourceGroupInfo> resourceInfos = infos[0].GetResourceGroups();
+                var pid = Windows.System.Diagnostics.ProcessDiagnosticInfo.GetForCurrentProcess().ProcessId;
+                await resourceInfos.Single(r => r.GetProcessDiagnosticInfos()[0].ProcessId == pid).StartTerminateAsync();
+                //Application.Current.Exit();
             }
             else if (((Window.Current.Content as Frame).Content as InstanceTabsView).TabStrip.TabItems.Count > 1)
             {

--- a/Files/Views/InstanceTabsView.xaml.cs
+++ b/Files/Views/InstanceTabsView.xaml.cs
@@ -3,12 +3,14 @@ using Files.Filesystem;
 using Files.Views.Pages;
 using Microsoft.UI.Xaml.Controls;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Windows.ApplicationModel.Core;
 using Windows.Storage;
+using Windows.System;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -401,7 +403,7 @@ namespace Files
             args.Handled = true;
         }
 
-        private void CloseSelectedTabKeyboardAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        private async void CloseSelectedTabKeyboardAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
         {
             var InvokedTabView = (args.Element as TabView);
 
@@ -410,7 +412,11 @@ namespace Files
             {
                 if (TabStrip.TabItems.Count == 1)
                 {
-                    Application.Current.Exit();
+                    IList<AppDiagnosticInfo> infos = await AppDiagnosticInfo.RequestInfoForAppAsync();
+                    IList<AppResourceGroupInfo> resourceInfos = infos[0].GetResourceGroups();
+                    var pid = Windows.System.Diagnostics.ProcessDiagnosticInfo.GetForCurrentProcess().ProcessId;                    
+                    await resourceInfos.Single(r => r.GetProcessDiagnosticInfos()[0].ProcessId == pid).StartTerminateAsync();
+                    //Application.Current.Exit();
                 }
                 else
                 {
@@ -478,11 +484,15 @@ namespace Files
             }
         }
 
-        private void TabStrip_TabCloseRequested(Microsoft.UI.Xaml.Controls.TabView sender, Microsoft.UI.Xaml.Controls.TabViewTabCloseRequestedEventArgs args)
+        private async void TabStrip_TabCloseRequested(Microsoft.UI.Xaml.Controls.TabView sender, Microsoft.UI.Xaml.Controls.TabViewTabCloseRequestedEventArgs args)
         {
             if (TabStrip.TabItems.Count == 1)
             {
-                Application.Current.Exit();
+                IList<AppDiagnosticInfo> infos = await AppDiagnosticInfo.RequestInfoForAppAsync();
+                IList<AppResourceGroupInfo> resourceInfos = infos[0].GetResourceGroups();
+                var pid = Windows.System.Diagnostics.ProcessDiagnosticInfo.GetForCurrentProcess().ProcessId;
+                await resourceInfos.Single(r => r.GetProcessDiagnosticInfos()[0].ProcessId == pid).StartTerminateAsync();
+                //Application.Current.Exit();
             }
             else if (TabStrip.TabItems.Count > 1)
             {

--- a/Files/Views/InstanceTabsView.xaml.cs
+++ b/Files/Views/InstanceTabsView.xaml.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
 using Windows.Storage;
 using Windows.System;
@@ -40,6 +41,15 @@ namespace Files
         }
 
         public static TabWindowProperties WindowProperties { get; set; } = new TabWindowProperties();
+
+        public static async Task StartTerminateAsync()
+        {
+            IList<AppDiagnosticInfo> infos = await AppDiagnosticInfo.RequestInfoForAppAsync();
+            IList<AppResourceGroupInfo> resourceInfos = infos[0].GetResourceGroups();
+            var pid = Windows.System.Diagnostics.ProcessDiagnosticInfo.GetForCurrentProcess().ProcessId;
+            await resourceInfos.Single(r => r.GetProcessDiagnosticInfos()[0].ProcessId == pid).StartTerminateAsync();
+            //Application.Current.Exit();
+        }
 
         private void Current_SizeChanged(object sender, Windows.UI.Core.WindowSizeChangedEventArgs e)
         {
@@ -412,11 +422,7 @@ namespace Files
             {
                 if (TabStrip.TabItems.Count == 1)
                 {
-                    IList<AppDiagnosticInfo> infos = await AppDiagnosticInfo.RequestInfoForAppAsync();
-                    IList<AppResourceGroupInfo> resourceInfos = infos[0].GetResourceGroups();
-                    var pid = Windows.System.Diagnostics.ProcessDiagnosticInfo.GetForCurrentProcess().ProcessId;                    
-                    await resourceInfos.Single(r => r.GetProcessDiagnosticInfos()[0].ProcessId == pid).StartTerminateAsync();
-                    //Application.Current.Exit();
+                    await InstanceTabsView.StartTerminateAsync();
                 }
                 else
                 {
@@ -488,18 +494,14 @@ namespace Files
         {
             if (TabStrip.TabItems.Count == 1)
             {
-                IList<AppDiagnosticInfo> infos = await AppDiagnosticInfo.RequestInfoForAppAsync();
-                IList<AppResourceGroupInfo> resourceInfos = infos[0].GetResourceGroups();
-                var pid = Windows.System.Diagnostics.ProcessDiagnosticInfo.GetForCurrentProcess().ProcessId;
-                await resourceInfos.Single(r => r.GetProcessDiagnosticInfos()[0].ProcessId == pid).StartTerminateAsync();
-                //Application.Current.Exit();
+                await InstanceTabsView.StartTerminateAsync();
             }
             else if (TabStrip.TabItems.Count > 1)
             {
                 int tabIndexToClose = TabStrip.TabItems.IndexOf(args.Tab);
                 TabStrip.TabItems.RemoveAt(tabIndexToClose);
             }
-        }
+        }        
 
         private void AddTabButton_Click(object sender, RoutedEventArgs e)
         {


### PR DESCRIPTION
This pull request changes the way the app is closed when the last tab is closed either with Ctrl+W or tab close button.

In the current implementation the ```Application.Current.Exit()``` method is called which results in an "ugly" closing animation: the app briefly shows an empty window and than the window closes abruptly looking like the app has crashed.

Instead this pull request uses the ```StartTerminateAsync()``` of the [diagnostic API](https://docs.microsoft.com/en-us/uwp/api/windows.system.appresourcegroupinfo.startterminateasync?view=winrt-18362) which results in the standard closing animation (like clicking the exit button on the titlebar) The method exists from the 1809 version and does not require additional app cababilities.

I do find this solution a bit of an overkill but I couldn't find a simpler way 😅