### PR TITLE
Recyclebin bugfix

### DIFF
--- a/Common/Extensions.cs
+++ b/Common/Extensions.cs
@@ -13,20 +13,5 @@ namespace Files.Common
 
             return (TOut)(object)dictionary[key];
         }
-
-        public static DateTime ToDateTime(this System.Runtime.InteropServices.ComTypes.FILETIME time)
-        {
-            ulong high = (ulong)time.dwHighDateTime;
-            uint low = (uint)time.dwLowDateTime;
-            long fileTime = (long)((high << 32) + low);
-            try
-            {
-                return DateTime.FromFileTimeUtc(fileTime);
-            }
-            catch
-            {
-                return DateTime.FromFileTimeUtc(0xFFFFFFFF);
-            }
-        }
     }
 }

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Vanara.Extensions;
 using Vanara.Windows.Shell;
 using Windows.ApplicationModel;
 using Windows.ApplicationModel.AppService;
@@ -162,6 +163,7 @@ namespace FilesFullTrust
                     else if (arguments == "RecycleBin")
                     {
                         var action = (string)args.Request.Message["action"];
+
                         if (action == "Empty")
                         {
                             // Shell function to empty recyclebin
@@ -200,7 +202,7 @@ namespace FilesFullTrust
                                     string fileName = Path.GetFileName(folderItem.Name); // Original file name
                                     string filePath = folderItem.Name; // Original file path + name
                                     var dt = (System.Runtime.InteropServices.ComTypes.FILETIME)folderItem.Properties[Vanara.PInvoke.Ole32.PROPERTYKEY.System.DateCreated];
-                                    var recycleDate = dt.ToDateTime().ToLocalTime(); // This is LocalTime
+                                    var recycleDate = dt.ToDateTime(DateTimeKind.Utc).ToLocalTime(); // Use LocalTime
                                     string fileSize = folderItem.Properties.GetPropertyString(Vanara.PInvoke.Ole32.PROPERTYKEY.System.Size);
                                     ulong fileSizeBytes = (ulong)folderItem.Properties[Vanara.PInvoke.Ole32.PROPERTYKEY.System.Size];
                                     string fileType = (string)folderItem.Properties[Vanara.PInvoke.Ole32.PROPERTYKEY.System.ItemTypeText];

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -70,6 +70,7 @@ namespace FilesFullTrust
                 recycler?.Dispose();
             }
 
+            mutex.ReleaseMutex();
             Logger.Info("Exiting: {0}", _id);
         }
 

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -40,10 +40,11 @@ namespace FilesFullTrust
 
             // Only one instance of the fulltrust process allowed
             // This happens if multiple instances of the UWP app are launched
-            var mutex = new Mutex(true, "FilesUwpFullTrust", out bool isNew);
+            using var mutex = new Mutex(true, @"Global\FilesUwpFullTrust", out bool isNew);
             if (!isNew) return;
 
             Logger.Info("Keep running: {0}, IsNew: {1}", _id, isNew);
+            Logger.Info("Keep running: {0}, Num proc: {1}", _id, Process.GetProcessesByName("FilesFullTrust").Count());
 
             // Create shell COM object and get recycle bin folder
             recycler = new ShellFolder(Vanara.PInvoke.Shell32.KNOWNFOLDERID.FOLDERID_RecycleBinFolder);
@@ -178,7 +179,7 @@ namespace FilesFullTrust
                     else if (arguments == "RecycleBin")
                     {
                         var action = (string)args.Request.Message["action"];
-                        Logger.Info("RecycleBin: {0}, Action: {0}", _id, action);
+                        Logger.Info("RecycleBin: {0}, Action: {1}", _id, action);
 
                         if (action == "Empty")
                         {

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -40,7 +40,7 @@ namespace FilesFullTrust
 
             // Only one instance of the fulltrust process allowed
             // This happens if multiple instances of the UWP app are launched
-            using var mutex = new Mutex(true, @"Global\FilesUwpFullTrust", out bool isNew);
+            using var mutex = new Mutex(true, @"FilesUwpFullTrust", out bool isNew);
             if (!isNew) return;
 
             Logger.Info("Keep running: {0}, IsNew: {1}", _id, isNew);


### PR DESCRIPTION
If you enable the recycle bin and open multiple instances of the app sometimes multiple instances of the fulltrust process will be launched.

This only happens for me when installing the latest commit compiled from Azure (if I compile the app locally in Release mode this does not happen).
This PR adds logging to the full trust process to debug this.

Please ignore this PR, I'll close it after getting the builds from azure.