### PR TITLE
Fix creating a folder or file with restricted names or characters

### DIFF
--- a/Files/Dialogs/RenameDialog.xaml
+++ b/Files/Dialogs/RenameDialog.xaml
@@ -19,9 +19,22 @@
     RequestedTheme="{x:Bind local2:ThemeHelper.RootTheme}">
 
     <Grid MinWidth="300">
-        <TextBox x:Name="RenameInput"
-                 x:Uid="RenameDialogInputText"
-                 PlaceholderText="Enter an item name without an extension"
-                 Height="35" />
+        <StackPanel
+            Orientation="Vertical"
+            Spacing="4">
+            <TextBox 
+                x:Name="RenameInput"
+                x:Uid="RenameDialogInputText"
+                PlaceholderText="Enter an item name without an extension"
+                Height="35"
+                TextChanged="RenameInput_TextChanged" />
+            <TextBlock
+                x:Name="RenameDialogSymbolsTip"
+                x:Uid="RenameDialogSymbolsTipUid"
+                Margin="0,0,4,0"
+                TextWrapping="Wrap"
+                Opacity="0"/>
+        </StackPanel>
+        
     </Grid>
 </ContentDialog>

--- a/Files/Dialogs/RenameDialog.xaml
+++ b/Files/Dialogs/RenameDialog.xaml
@@ -30,7 +30,7 @@
                 TextChanged="RenameInput_TextChanged" />
             <TextBlock
                 x:Name="RenameDialogSymbolsTip"
-                x:Uid="RenameDialogSymbolsTipUid"
+                x:Uid="RenameDialogSymbolsTip"
                 Margin="0,0,4,0"
                 TextWrapping="Wrap"
                 Opacity="0"/>

--- a/Files/Dialogs/RenameDialog.xaml.cs
+++ b/Files/Dialogs/RenameDialog.xaml.cs
@@ -28,6 +28,7 @@ namespace Files.Dialogs
             {
                 RenameDialogSymbolsTip.Opacity = 1;
                 IsPrimaryButtonEnabled = false;
+                return;
             }
             else
             {

--- a/Files/Dialogs/RenameDialog.xaml.cs
+++ b/Files/Dialogs/RenameDialog.xaml.cs
@@ -19,5 +19,30 @@ namespace Files.Dialogs
         {
             storedRenameInput = inputBox.Text;
         }
+
+        private void RenameInput_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            var textBox = sender as TextBox;
+
+            if (App.CurrentInstance.InteractionOperations.ContainsRestrictedCharacters(textBox.Text))
+            {
+                RenameDialogSymbolsTip.Opacity = 1;
+                IsPrimaryButtonEnabled = false;
+            }
+            else
+            {
+                RenameDialogSymbolsTip.Opacity = 0;
+                IsPrimaryButtonEnabled = true;
+            }
+
+            if (App.CurrentInstance.InteractionOperations.ContainsRestrictedFileName(textBox.Text))
+            {
+                IsPrimaryButtonEnabled = false;
+            }
+            else
+            {
+                IsPrimaryButtonEnabled = true;
+            }
+        }
     }
 }

--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -776,6 +776,18 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+          <source>OK</source>
+          <target state="new">OK</target>
+        </trans-unit>
+        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -776,15 +776,15 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.Subtitle" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.CloseButtonContent" translate="yes" xml:space="preserve">
           <source>OK</source>
           <target state="new">OK</target>
         </trans-unit>
-        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RenameDialogSymbolsTip.Text" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -774,6 +774,18 @@
           <source>Open With</source>
           <target state="translated">Abrir con</target>
         </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+          <source>OK</source>
+          <target state="new">OK</target>
+        </trans-unit>
+        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -774,15 +774,15 @@
           <source>Open With</source>
           <target state="translated">Abrir con</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.Subtitle" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.CloseButtonContent" translate="yes" xml:space="preserve">
           <source>OK</source>
           <target state="new">OK</target>
         </trans-unit>
-        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RenameDialogSymbolsTip.Text" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -777,15 +777,15 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.Subtitle" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.CloseButtonContent" translate="yes" xml:space="preserve">
           <source>OK</source>
           <target state="new">OK</target>
         </trans-unit>
-        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RenameDialogSymbolsTip.Text" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -777,6 +777,18 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+          <source>OK</source>
+          <target state="new">OK</target>
+        </trans-unit>
+        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -776,6 +776,18 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+          <source>OK</source>
+          <target state="new">OK</target>
+        </trans-unit>
+        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -776,15 +776,15 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.Subtitle" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.CloseButtonContent" translate="yes" xml:space="preserve">
           <source>OK</source>
           <target state="new">OK</target>
         </trans-unit>
-        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RenameDialogSymbolsTip.Text" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -777,15 +777,15 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.Subtitle" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.CloseButtonContent" translate="yes" xml:space="preserve">
           <source>OK</source>
           <target state="new">OK</target>
         </trans-unit>
-        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RenameDialogSymbolsTip.Text" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -777,6 +777,18 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+          <source>OK</source>
+          <target state="new">OK</target>
+        </trans-unit>
+        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -777,15 +777,15 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.Subtitle" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.CloseButtonContent" translate="yes" xml:space="preserve">
           <source>OK</source>
           <target state="new">OK</target>
         </trans-unit>
-        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RenameDialogSymbolsTip.Text" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -777,6 +777,18 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+          <source>OK</source>
+          <target state="new">OK</target>
+        </trans-unit>
+        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -775,6 +775,18 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+          <source>OK</source>
+          <target state="new">OK</target>
+        </trans-unit>
+        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -152,8 +152,7 @@
         </trans-unit>
         <trans-unit id="SettingsOnStartupOpenASpecificPage.Content" translate="yes" xml:space="preserve">
           <source>Open a specific page</source>
-          <target state="needs-review-translation">Открыть определенную страницу(ы)</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="translated">Открыть определенную страницу(ы)</target>
         </trans-unit>
         <trans-unit id="SettingsOnStartupTitle.Text" translate="yes" xml:space="preserve">
           <source>On Startup</source>
@@ -765,27 +764,27 @@
         </trans-unit>
         <trans-unit id="SettingsOnStartupOpenASpecificPagePath.PlaceholderText" translate="yes" xml:space="preserve">
           <source>New Tab</source>
-          <target state="new">New Tab</target>
+          <target state="translated">Новая вкладка</target>
         </trans-unit>
         <trans-unit id="ErrorDialogUnsupportedOperation" translate="yes" xml:space="preserve">
           <source>The requested operation is not supported</source>
-          <target state="new">The requested operation is not supported</target>
+          <target state="translated">Запрошенная операция не поддерживается</target>
         </trans-unit>
         <trans-unit id="BaseLayoutItemContextFlyoutOpenItemWith.Text" translate="yes" xml:space="preserve">
           <source>Open With</source>
-          <target state="new">Open With</target>
+          <target state="translated">Открыть с помощью</target>
         </trans-unit>
         <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
-          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+          <target state="translated">Имя элемента не должно содержать следующих знаков: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>
         <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
           <source>OK</source>
-          <target state="new">OK</target>
+          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
-          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+          <target state="translated">Имя элемента не должно содержать следующих знаков: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -774,15 +774,15 @@
           <source>Open With</source>
           <target state="translated">Открыть с помощью</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.Subtitle" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="translated">Имя элемента не должно содержать следующих знаков: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.CloseButtonContent" translate="yes" xml:space="preserve">
           <source>OK</source>
           <target state="translated">OK</target>
         </trans-unit>
-        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RenameDialogSymbolsTip.Text" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="translated">Имя элемента не должно содержать следующих знаков: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -775,6 +775,18 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+          <source>OK</source>
+          <target state="new">OK</target>
+        </trans-unit>
+        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -775,15 +775,15 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.Subtitle" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.CloseButtonContent" translate="yes" xml:space="preserve">
           <source>OK</source>
           <target state="new">OK</target>
         </trans-unit>
-        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RenameDialogSymbolsTip.Text" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -777,15 +777,15 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.Subtitle" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.CloseButtonContent" translate="yes" xml:space="preserve">
           <source>OK</source>
           <target state="new">OK</target>
         </trans-unit>
-        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RenameDialogSymbolsTip.Text" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -777,6 +777,18 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+          <source>OK</source>
+          <target state="new">OK</target>
+        </trans-unit>
+        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -260,8 +260,7 @@
         </trans-unit>
         <trans-unit id="SettingsOnStartupOpenASpecificPage.Content" translate="yes" xml:space="preserve">
           <source>Open a specific page</source>
-          <target state="needs-review-translation">Відкрити певну сторінку або сторінки</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="translated">Відкрити певну сторінку або сторінки</target>
         </trans-unit>
         <trans-unit id="SettingsOnStartupTitle.Text" translate="yes" xml:space="preserve">
           <source>On Startup</source>
@@ -765,27 +764,27 @@
         </trans-unit>
         <trans-unit id="SettingsOnStartupOpenASpecificPagePath.PlaceholderText" translate="yes" xml:space="preserve">
           <source>New Tab</source>
-          <target state="new">New Tab</target>
+          <target state="translated">Нова вкладка</target>
         </trans-unit>
         <trans-unit id="ErrorDialogUnsupportedOperation" translate="yes" xml:space="preserve">
           <source>The requested operation is not supported</source>
-          <target state="new">The requested operation is not supported</target>
+          <target state="translated">Дана операція не підтримується</target>
         </trans-unit>
         <trans-unit id="BaseLayoutItemContextFlyoutOpenItemWith.Text" translate="yes" xml:space="preserve">
           <source>Open With</source>
-          <target state="new">Open With</target>
+          <target state="translated">Відкрити за допомогою</target>
         </trans-unit>
         <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
-          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+          <target state="translated">Ім'я елемента не повинно містити таких знаків: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>
         <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
           <source>OK</source>
-          <target state="new">OK</target>
+          <target state="translated">OK</target>
         </trans-unit>
         <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
-          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+          <target state="translated">Ім'я елемента не повинно містити таких знаків: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -775,6 +775,18 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+          <source>OK</source>
+          <target state="new">OK</target>
+        </trans-unit>
+        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -774,15 +774,15 @@
           <source>Open With</source>
           <target state="translated">Відкрити за допомогою</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.Subtitle" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="translated">Ім'я елемента не повинно містити таких знаків: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.CloseButtonContent" translate="yes" xml:space="preserve">
           <source>OK</source>
           <target state="translated">OK</target>
         </trans-unit>
-        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RenameDialogSymbolsTip.Text" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="translated">Ім'я елемента не повинно містити таких знаків: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -777,15 +777,15 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.Subtitle" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>
-        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+        <trans-unit id="FileNameTeachingTip.CloseButtonContent" translate="yes" xml:space="preserve">
           <source>OK</source>
           <target state="new">OK</target>
         </trans-unit>
-        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="RenameDialogSymbolsTip.Text" translate="yes" xml:space="preserve">
           <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
           <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -777,6 +777,18 @@
           <source>Open With</source>
           <target state="new">Open With</target>
         </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.Subtitle" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
+        <trans-unit id="FileNameTeachingTipUid.CloseButtonContent" translate="yes" xml:space="preserve">
+          <source>OK</source>
+          <target state="new">OK</target>
+        </trans-unit>
+        <trans-unit id="RenameDialogSymbolsTipUid.Text" translate="yes" xml:space="preserve">
+          <source>The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</source>
+          <target state="new">The item name must not contain the following characters: \ / : * ? " <it id="1" pos="open">&lt; &gt;</it> |</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -693,13 +693,13 @@
   <data name="BaseLayoutItemContextFlyoutOpenItemWith.Text" xml:space="preserve">
     <value>Open With</value>
   </data>
-  <data name="FileNameTeachingTipUid.Subtitle" xml:space="preserve">
+  <data name="FileNameTeachingTip.Subtitle" xml:space="preserve">
     <value>The item name must not contain the following characters: \ / : * ? &quot; &lt; &gt; |</value>
   </data>
-  <data name="FileNameTeachingTipUid.CloseButtonContent" xml:space="preserve">
+  <data name="FileNameTeachingTip.CloseButtonContent" xml:space="preserve">
     <value>OK</value>
   </data>
-    <data name="RenameDialogSymbolsTipUid.Text" xml:space="preserve">
+    <data name="RenameDialogSymbolsTip.Text" xml:space="preserve">
     <value>The item name must not contain the following characters: \ / : * ? &quot; &lt; &gt; |</value>
   </data>
 </root>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -693,4 +693,13 @@
   <data name="BaseLayoutItemContextFlyoutOpenItemWith.Text" xml:space="preserve">
     <value>Open With</value>
   </data>
+  <data name="FileNameTeachingTipUid.Subtitle" xml:space="preserve">
+    <value>The item name must not contain the following characters: \ / : * ? &quot; &lt; &gt; |</value>
+  </data>
+  <data name="FileNameTeachingTipUid.CloseButtonContent" xml:space="preserve">
+    <value>OK</value>
+  </data>
+    <data name="RenameDialogSymbolsTipUid.Text" xml:space="preserve">
+    <value>The item name must not contain the following characters: \ / : * ? &quot; &lt; &gt; |</value>
+  </data>
 </root>

--- a/Files/Strings/ru-RU/Resources.resw
+++ b/Files/Strings/ru-RU/Resources.resw
@@ -576,4 +576,22 @@
   <data name="DriveFreeSpaceAndCapacity" xml:space="preserve">
     <value>{0} свободно из {1}</value>
   </data>
+  <data name="SettingsOnStartupOpenASpecificPagePath.PlaceholderText" xml:space="preserve">
+    <value>Новая вкладка</value>
+  </data>
+  <data name="ErrorDialogUnsupportedOperation" xml:space="preserve">
+    <value>Запрошенная операция не поддерживается</value>
+  </data>
+  <data name="BaseLayoutItemContextFlyoutOpenItemWith.Text" xml:space="preserve">
+    <value>Открыть с помощью</value>
+  </data>
+  <data name="FileNameTeachingTipUid.Subtitle" xml:space="preserve">
+    <value>Имя элемента не должно содержать следующих знаков: \ / : * ? " &lt; &gt; |</value>
+  </data>
+  <data name="FileNameTeachingTipUid.CloseButtonContent" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="RenameDialogSymbolsTipUid.Text" xml:space="preserve">
+    <value>Имя элемента не должно содержать следующих знаков: \ / : * ? " &lt; &gt; |</value>
+  </data>
 </root>

--- a/Files/Strings/ru-RU/Resources.resw
+++ b/Files/Strings/ru-RU/Resources.resw
@@ -585,13 +585,13 @@
   <data name="BaseLayoutItemContextFlyoutOpenItemWith.Text" xml:space="preserve">
     <value>Открыть с помощью</value>
   </data>
-  <data name="FileNameTeachingTipUid.Subtitle" xml:space="preserve">
+  <data name="FileNameTeachingTip.Subtitle" xml:space="preserve">
     <value>Имя элемента не должно содержать следующих знаков: \ / : * ? " &lt; &gt; |</value>
   </data>
-  <data name="FileNameTeachingTipUid.CloseButtonContent" xml:space="preserve">
+  <data name="FileNameTeachingTip.CloseButtonContent" xml:space="preserve">
     <value>OK</value>
   </data>
-  <data name="RenameDialogSymbolsTipUid.Text" xml:space="preserve">
+  <data name="RenameDialogSymbolsTip.Text" xml:space="preserve">
     <value>Имя элемента не должно содержать следующих знаков: \ / : * ? " &lt; &gt; |</value>
   </data>
 </root>

--- a/Files/Strings/uk-UA/Resources.resw
+++ b/Files/Strings/uk-UA/Resources.resw
@@ -579,13 +579,13 @@
   <data name="BaseLayoutItemContextFlyoutOpenItemWith.Text" xml:space="preserve">
     <value>Відкрити за допомогою</value>
   </data>
-  <data name="FileNameTeachingTipUid.Subtitle" xml:space="preserve">
+  <data name="FileNameTeachingTip.Subtitle" xml:space="preserve">
     <value>Ім'я елемента не повинно містити таких знаків: \ / : * ? " &lt; &gt; |</value>
   </data>
-  <data name="FileNameTeachingTipUid.CloseButtonContent" xml:space="preserve">
+  <data name="FileNameTeachingTip.CloseButtonContent" xml:space="preserve">
     <value>OK</value>
   </data>
-  <data name="RenameDialogSymbolsTipUid.Text" xml:space="preserve">
+  <data name="RenameDialogSymbolsTip.Text" xml:space="preserve">
     <value>Ім'я елемента не повинно містити таких знаків: \ / : * ? " &lt; &gt; |</value>
   </data>
 </root>

--- a/Files/Strings/uk-UA/Resources.resw
+++ b/Files/Strings/uk-UA/Resources.resw
@@ -570,4 +570,22 @@
   <data name="DriveFreeSpaceAndCapacity" xml:space="preserve">
     <value>{0} вільно з {1}</value>
   </data>
+  <data name="SettingsOnStartupOpenASpecificPagePath.PlaceholderText" xml:space="preserve">
+    <value>Нова вкладка</value>
+  </data>
+  <data name="ErrorDialogUnsupportedOperation" xml:space="preserve">
+    <value>Дана операція не підтримується</value>
+  </data>
+  <data name="BaseLayoutItemContextFlyoutOpenItemWith.Text" xml:space="preserve">
+    <value>Відкрити за допомогою</value>
+  </data>
+  <data name="FileNameTeachingTipUid.Subtitle" xml:space="preserve">
+    <value>Ім'я елемента не повинно містити таких знаків: \ / : * ? " &lt; &gt; |</value>
+  </data>
+  <data name="FileNameTeachingTipUid.CloseButtonContent" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="RenameDialogSymbolsTipUid.Text" xml:space="preserve">
+    <value>Ім'я елемента не повинно містити таких знаків: \ / : * ? " &lt; &gt; |</value>
+  </data>
 </root>

--- a/Files/UserControls/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/UserControls/LayoutModes/GenericFileBrowser.xaml
@@ -386,7 +386,7 @@
 
         <muxc:TeachingTip
             x:Name="FileNameTeachingTip"
-            x:Uid="FileNameTeachingTipUid"
+            x:Uid="FileNameTeachingTip"
             Subtitle="The item name must not contain the following characters: \ / : * ? &quot; &lt; &gt; |"
             PreferredPlacement="Auto"
             CloseButtonContent="OK" />

--- a/Files/UserControls/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/UserControls/LayoutModes/GenericFileBrowser.xaml
@@ -384,6 +384,13 @@
             TextWrapping="Wrap"
             Visibility="{x:Bind AssociatedViewModel.EmptyTextState.IsVisible, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
+        <muxc:TeachingTip
+            x:Name="FileNameTeachingTip"
+            x:Uid="FileNameTeachingTipUid"
+            Subtitle="The item name must not contain the following characters: \ / : * ? &quot; &lt; &gt; |"
+            PreferredPlacement="Auto"
+            CloseButtonContent="OK" />
+
         <controls:DataGrid
             x:Name="AllView"
             Grid.Row="3"

--- a/Files/UserControls/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/UserControls/LayoutModes/GenericFileBrowser.xaml.cs
@@ -20,7 +20,7 @@ namespace Files
 {
     public sealed partial class GenericFileBrowser : BaseLayout
     {
-        public string previousFileName;
+        private string oldItemName;
         private DataGridColumn _sortedColumn;
 
         public DataGridColumn SortedColumn
@@ -237,6 +237,7 @@ namespace Files
             }
         }
 
+        private TextBox renamingTextBox;
         private void AllView_PreparingCellForEdit(object sender, DataGridPreparingCellForEditEventArgs e)
         {
             if (App.CurrentInstance.ViewModel.WorkingDirectory.StartsWith(App.AppSettings.RecycleBinPath))
@@ -254,35 +255,54 @@ namespace Files
                 return;
             }
 
-            var textBox = e.EditingElement as TextBox;
-            var selectedItem = SelectedItem;
-            int extensionLength = selectedItem.FileExtension?.Length ?? 0;
+            int extensionLength = SelectedItem.FileExtension?.Length ?? 0;
+            oldItemName = SelectedItem.ItemName;
 
-            previousFileName = selectedItem.ItemName;
-            textBox.Focus(FocusState.Programmatic); // Without this, cannot edit text box when renaming via right-click
-            textBox.Select(0, selectedItem.ItemName.Length - extensionLength);
+            renamingTextBox = e.EditingElement as TextBox;
+            renamingTextBox.Focus(FocusState.Programmatic); // Without this, cannot edit text box when renaming via right-click
+            renamingTextBox.Select(0, SelectedItem.ItemName.Length - extensionLength);
+            renamingTextBox.TextChanged += TextBox_TextChanged;
             isRenamingItem = true;
+        }
+
+        private void TextBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            var textBox = sender as TextBox;
+
+            if (App.CurrentInstance.InteractionOperations.ContainsRestrictedCharacters(textBox.Text))
+            {
+                FileNameTeachingTip.IsOpen = true;
+            }
+            else
+            {
+                FileNameTeachingTip.IsOpen = false;
+            }
         }
 
         private async void AllView_CellEditEnding(object sender, DataGridCellEditEndingEventArgs e)
         {
             if (e.EditAction == DataGridEditAction.Cancel)
+            {
                 return;
+            }
+
+            renamingTextBox.Text = renamingTextBox.Text.Trim(new char[] { ' ', '.' });
 
             var selectedItem = e.Row.DataContext as ListedItem;
-            string currentName = previousFileName;
-            string newName = (e.EditingElement as TextBox).Text;
+            string newItemName = renamingTextBox.Text;
 
-            bool successful = await App.CurrentInstance.InteractionOperations.RenameFileItem(selectedItem, currentName, newName);
+            bool successful = await App.CurrentInstance.InteractionOperations.RenameFileItem(selectedItem, oldItemName, newItemName);
             if (!successful)
             {
-                selectedItem.ItemName = currentName;
-                ((sender as DataGrid).Columns[1].GetCellContent(e.Row) as TextBlock).Text = currentName;
+                selectedItem.ItemName = oldItemName;
+                renamingTextBox.Text = oldItemName;
             }
         }
 
         private void AllView_CellEditEnded(object sender, DataGridCellEditEndedEventArgs e)
         {
+            renamingTextBox.TextChanged -= TextBox_TextChanged;
+            FileNameTeachingTip.IsOpen = false;
             isRenamingItem = false;
         }
 

--- a/Files/UserControls/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/UserControls/LayoutModes/GenericFileBrowser.xaml.cs
@@ -286,7 +286,7 @@ namespace Files
                 return;
             }
 
-            renamingTextBox.Text = renamingTextBox.Text.Trim(new char[] { ' ', '.' });
+            renamingTextBox.Text = renamingTextBox.Text.Trim().TrimEnd('.');
 
             var selectedItem = e.Row.DataContext as ListedItem;
             string newItemName = renamingTextBox.Text;

--- a/Files/UserControls/LayoutModes/GridViewBrowser.xaml
+++ b/Files/UserControls/LayoutModes/GridViewBrowser.xaml
@@ -1,4 +1,4 @@
-﻿<local:BaseLayout
+<local:BaseLayout
     x:Class="Files.GridViewBrowser"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -414,13 +414,15 @@
                     Grid.Row="1"
                     x:Load="False">
                     <TextBox
+                        x:Name="GridViewTextBoxItemName"
                         Width="{x:Bind local:App.AppSettings.GridViewSize, Mode=OneWay}"
                         Margin="0"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
                         Text="{x:Bind ItemName}"
                         TextAlignment="Center"
-                        TextWrapping="Wrap" />
+                        TextWrapping="Wrap"
+                        TextChanged="GridViewTextBoxItemName_TextChanged" />
                 </Popup>
             </Grid>
         </DataTemplate>
@@ -575,6 +577,13 @@
             Text="This folder is empty."
             TextWrapping="Wrap"
             Visibility="{x:Bind AssociatedViewModel.EmptyTextState.IsVisible, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+        <muxc:TeachingTip
+            x:Name="FileNameTeachingTip"
+            x:Uid="FileNameTeachingTipUid"
+            Subtitle="The file name must not contain the following characters: \ / : * ? &quot; &lt; &gt; |"
+            PreferredPlacement="Auto"
+            CloseButtonContent="OK"/>
 
         <GridView
             x:Name="FileList"

--- a/Files/UserControls/LayoutModes/GridViewBrowser.xaml
+++ b/Files/UserControls/LayoutModes/GridViewBrowser.xaml
@@ -580,7 +580,7 @@
 
         <muxc:TeachingTip
             x:Name="FileNameTeachingTip"
-            x:Uid="FileNameTeachingTipUid"
+            x:Uid="FileNameTeachingTip"
             Subtitle="The file name must not contain the following characters: \ / : * ? &quot; &lt; &gt; |"
             PreferredPlacement="Auto"
             CloseButtonContent="OK"/>

--- a/Files/UserControls/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/UserControls/LayoutModes/GridViewBrowser.xaml.cs
@@ -241,7 +241,7 @@ namespace Files
         private async void CommitRename(TextBox textBox)
         {
             EndRename(textBox);
-            string newItemName = textBox.Text.Trim(new char[] { ' ', '.' });
+            string newItemName = textBox.Text.Trim().TrimEnd('.');
 
             bool successful = await App.CurrentInstance.InteractionOperations.RenameFileItem(renamingItem, oldItemName, newItemName);
             if (!successful)

--- a/Files/UserControls/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/UserControls/LayoutModes/GridViewBrowser.xaml.cs
@@ -14,6 +14,8 @@ namespace Files
 {
     public sealed partial class GridViewBrowser : BaseLayout
     {
+        public string oldItemName;
+
         public GridViewBrowser()
         {
             this.InitializeComponent();
@@ -149,7 +151,9 @@ namespace Files
                 Popup popup = (gridViewItem.ContentTemplateRoot as Grid).FindName("EditPopup") as Popup;
                 TextBlock textBlock = (gridViewItem.ContentTemplateRoot as Grid).Children[1] as TextBlock;
                 textBox = popup.Child as TextBox;
+                textBox.Text = textBlock.Text;
                 popup.IsOpen = true;
+                oldItemName = textBlock.Text;
             }
             else
             {
@@ -157,6 +161,8 @@ namespace Files
                     (((gridViewItem.ContentTemplateRoot as Grid).Children[0] as StackPanel).Children[1] as Grid).Children[0] as StackPanel;
                 TextBlock textBlock = stackPanel.Children[0] as TextBlock;
                 textBox = stackPanel.Children[1] as TextBox;
+                textBox.Text = textBlock.Text;
+                oldItemName = textBlock.Text;
                 textBlock.Visibility = Visibility.Collapsed;
                 textBox.Visibility = Visibility.Visible;
             }
@@ -167,6 +173,20 @@ namespace Files
             textBox.Select(0, renamingItem.ItemName.Length - extensionLength);
 
             isRenamingItem = true;
+        }
+
+        private void GridViewTextBoxItemName_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            var textBox = sender as TextBox;
+
+            if (App.CurrentInstance.InteractionOperations.ContainsRestrictedCharacters(textBox.Text))
+            {
+                FileNameTeachingTip.IsOpen = true;
+            }
+            else
+            {
+                FileNameTeachingTip.IsOpen = false;
+            }
         }
 
         public override void ResetItemOpacity()
@@ -200,6 +220,7 @@ namespace Files
             {
                 TextBox textBox = sender as TextBox;
                 textBox.LostFocus -= RenameTextBox_LostFocus;
+                textBox.Text = oldItemName;
                 EndRename(textBox);
                 e.Handled = true;
             }
@@ -220,21 +241,20 @@ namespace Files
         private async void CommitRename(TextBox textBox)
         {
             EndRename(textBox);
-            var selectedItem = renamingItem;
-            string currentName = selectedItem.ItemName;
-            string newName = textBox.Text;
+            string newItemName = textBox.Text.Trim(new char[] { ' ', '.' });
 
-            if (newName == null)
-                return;
-
-            await App.CurrentInstance.InteractionOperations.RenameFileItem(selectedItem, currentName, newName);
+            bool successful = await App.CurrentInstance.InteractionOperations.RenameFileItem(renamingItem, oldItemName, newItemName);
+            if (!successful)
+            {
+                renamingItem.ItemName = oldItemName;
+            }
         }
 
         private void EndRename(TextBox textBox)
         {
             if (App.AppSettings.LayoutMode == 2)
             {
-                Popup popup = (textBox.Parent) as Popup;
+                Popup popup = textBox.Parent as Popup;
                 TextBlock textBlock = (popup.Parent as Grid).Children[1] as TextBlock;
                 popup.IsOpen = false;
             }
@@ -248,6 +268,7 @@ namespace Files
 
             textBox.LostFocus -= RenameTextBox_LostFocus;
             textBox.KeyDown -= RenameTextBox_KeyDown;
+            FileNameTeachingTip.IsOpen = false;
             isRenamingItem = false;
         }
 


### PR DESCRIPTION
Fixes #630 
Fixes [this](https://github.com/files-community/files-uwp/pull/898#issuecomment-639617546)

How it looks when user types restricted character:
![image](https://user-images.githubusercontent.com/20501502/83972580-a0fcf480-a8e9-11ea-9a52-573063188ca1.png)
The same in rename dialog:
![image](https://user-images.githubusercontent.com/20501502/83972624-dc97be80-a8e9-11ea-9285-94cfef513f9d.png)
