### PR TITLE
Change how to get Dispatcher

### DIFF
--- a/Files/Filesystem/Drives.cs
+++ b/Files/Filesystem/Drives.cs
@@ -18,7 +18,7 @@ namespace Files.Filesystem
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public ObservableCollection<DriveItem> Drives { get; } = new ObservableCollection<DriveItem>();
+        public IList<DriveItem> Drives { get; } = new List<DriveItem>();
         public bool ShowUserConsentOnInit { get; set; } = false;
         private DeviceWatcher _deviceWatcher;
 
@@ -51,7 +51,7 @@ namespace Files.Filesystem
         {
             try
             {
-                await CoreApplication.MainView.Dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
+                await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
                 {
                     if (App.sideBarItems.FirstOrDefault(x => x is HeaderTextItem && x.Text == ResourceController.GetTranslation("SidebarDrives")) == null)
                     {
@@ -82,7 +82,7 @@ namespace Files.Filesystem
 
         private async void MainView_Activated(CoreApplicationView sender, Windows.ApplicationModel.Activation.IActivatedEventArgs args)
         {
-            await CoreApplication.MainView.Dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
+            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
             {
                 if (App.sideBarItems.FirstOrDefault(x => x is HeaderTextItem && x.Text == ResourceController.GetTranslation("SidebarDrives")) == null)
                 {
@@ -133,7 +133,7 @@ namespace Files.Filesystem
             // Update the collection on the ui-thread.
             try
             {
-                CoreApplication.MainView.Dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
+                await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
                 {
                     Drives.Add(driveItem);
                     DeviceWatcher_EnumerationCompleted(null, null);
@@ -162,7 +162,7 @@ namespace Files.Filesystem
                 // Update the collection on the ui-thread.
                 try
                 {
-                    CoreApplication.MainView.Dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
+                    await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
                     {
                         Drives.Remove(drive);
                         DeviceWatcher_EnumerationCompleted(null, null);

--- a/Files/Helpers/ThemeHelper.cs
+++ b/Files/Helpers/ThemeHelper.cs
@@ -1,4 +1,5 @@
-﻿using Windows.Storage;
+﻿using System;
+using Windows.Storage;
 using Windows.UI;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
@@ -90,13 +91,13 @@ namespace Files.Helpers
             UiSettings.ColorValuesChanged += UiSettings_ColorValuesChanged;
         }
 
-        private static void UiSettings_ColorValuesChanged(UISettings sender, object args)
+        private static async void UiSettings_ColorValuesChanged(UISettings sender, object args)
         {
             // Make sure we have a reference to our window so we dispatch a UI change
             if (_CurrentApplicationWindow != null)
             {
                 // Dispatch on UI thread so that we have a current appbar to access and change
-                _CurrentApplicationWindow.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.High, () =>
+                await _CurrentApplicationWindow.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.High, () =>
                 {
                     UpdateTheme();
                 });

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -1067,7 +1067,7 @@ namespace Files.Interacts
                     .ContinueWith(async (x) =>
                 {
                     await destFolder_InBuffer.DeleteAsync(StorageDeleteOption.PermanentDelete);
-                    await CoreApplication.MainView.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                    await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                     {
                         Frame rootFrame = Window.Current.Content as Frame;
                         var instanceTabsView = rootFrame.Content as InstanceTabsView;

--- a/Files/Views/SettingsPages/Preferences.xaml.cs
+++ b/Files/Views/SettingsPages/Preferences.xaml.cs
@@ -2,6 +2,7 @@
 using Files.View_Models;
 using Newtonsoft.Json;
 using System;
+using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.System;
 using Windows.UI.Xaml.Controls;
@@ -19,15 +20,12 @@ namespace Files.SettingsPages
         {
             this.InitializeComponent();
 
-            try
-            {
-                StorageFolder.GetFolderFromPathAsync(App.AppSettings.OneDrivePath);
-            }
-            catch (Exception)
-            {
-                App.AppSettings.PinOneDriveToSideBar = false;
-                OneDrivePin.IsEnabled = false;
-            }
+            StorageFolder.GetFolderFromPathAsync(App.AppSettings.OneDrivePath).AsTask()
+                    .ContinueWith((t) =>
+                {
+                    App.AppSettings.PinOneDriveToSideBar = false;
+                    OneDrivePin.IsEnabled = false;
+                }, TaskContinuationOptions.OnlyOnFaulted);
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)

--- a/Files/Views/SettingsPages/Preferences.xaml.cs
+++ b/Files/Views/SettingsPages/Preferences.xaml.cs
@@ -2,6 +2,7 @@
 using Files.View_Models;
 using Newtonsoft.Json;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.System;
@@ -25,7 +26,7 @@ namespace Files.SettingsPages
                 {
                     App.AppSettings.PinOneDriveToSideBar = false;
                     OneDrivePin.IsEnabled = false;
-                }, TaskContinuationOptions.OnlyOnFaulted);
+                }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.FromCurrentSynchronizationContext());
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)


### PR DESCRIPTION
This PR:
- may fix the issue of drives not appearing on the sidebar #930 
- *fixes* the issue of removable drives not always appearing/disappearing from the sidebar when connected/disconnected

Basically it changes how to get the UI Dispatcher
- CoreApplication.MainView.Dispatcher -> this often results in `System.Exception` even when app has started
- CoreApplication.MainView.CoreWindow.Dispatcher -> seems ok

Can someone confirm this? (and explain me what the difference is? 😅)

This PR also makes sure that async methods inside a try-catch are always awaited as I don't think that exceptions are caught if the method is not awaited.

```cs
try
{
    StorageFolder.GetFolderFromPathAsync(App.AppSettings.OneDrivePath); ----> async without await
}
catch (Exception) ----> the exception can't be caught
{
    App.AppSettings.PinOneDriveToSideBar = false;
}
```