### PR TITLE
Added keyboard shortcuts to the tooltip of buttons in the navigation bar

### DIFF
--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -501,12 +501,12 @@
           <target state="translated">Dieser Ordner ist leer.</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back (Alt + Left arrow)</source>
+          <source>Back (Alt + Left Arrow)</source>
           <target state="needs-review-translation">Zurück</target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward (Alt + Right arrow)</source>
+          <source>Forward (Alt + Right Arrow)</source>
           <target state="needs-review-translation">Vorwärts</target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
@@ -797,7 +797,7 @@
           <source>Open Log location</source>
           <target state="new">Open Log location</target>
         </trans-unit>
-        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+        <trans-unit id="TabStripAddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>New tab (Ctrl + T)</source>
           <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -501,24 +501,29 @@
           <target state="translated">Dieser Ordner ist leer.</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back</source>
-          <target state="translated">Zurück</target>
+          <source>Back (Alt + Left arrow)</source>
+          <target state="needs-review-translation">Zurück</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward</source>
-          <target state="translated">Vorwärts</target>
+          <source>Forward (Alt + Right arrow)</source>
+          <target state="needs-review-translation">Vorwärts</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavUpButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Up</source>
-          <target state="translated">Hoch</target>
+          <source>Up (Alt + Up Arrow)</source>
+          <target state="needs-review-translation">Hoch</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavRefreshButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Refresh</source>
-          <target state="translated">Aktualisieren</target>
+          <source>Refresh (F5)</source>
+          <target state="needs-review-translation">Aktualisieren</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavNewItemButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Create a new item</source>
-          <target state="translated">Neue Datei erstellen</target>
+          <source>Create a new item (Ctrl + Shift + N)</source>
+          <target state="needs-review-translation">Neue Datei erstellen</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavSearchButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Search</source>
@@ -791,6 +796,10 @@
         <trans-unit id="SettingsAboutOpenLogLocationButton.Content" translate="yes" xml:space="preserve">
           <source>Open Log location</source>
           <target state="new">Open Log location</target>
+        </trans-unit>
+        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>New tab (Ctrl + T)</source>
+          <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -499,24 +499,24 @@
           <target state="translated">Esta carpeta está vacía.</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back</source>
-          <target state="translated">Atrás</target>
+          <source>Back (Alt + Left arrow)</source>
+          <target state="translated">Atrás (Alt + Flecha izquierda)</target>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward</source>
-          <target state="translated">Adelante</target>
+          <source>Forward (Alt + Right arrow)</source>
+          <target state="translated">Adelante (Alt + Flecha derecha)</target>
         </trans-unit>
         <trans-unit id="NavUpButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Up</source>
-          <target state="translated">Arriba</target>
+          <source>Up (Alt + Up Arrow)</source>
+          <target state="translated">Arriba (Alt + Flecha arriba)</target>
         </trans-unit>
         <trans-unit id="NavRefreshButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Refresh</source>
-          <target state="translated">Actualizar</target>
+          <source>Refresh (F5)</source>
+          <target state="translated">Actualizar (F5)</target>
         </trans-unit>
         <trans-unit id="NavNewItemButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Create a new item</source>
-          <target state="translated">Crear un nuevo elemento</target>
+          <source>Create a new item (Ctrl + Shift + N)</source>
+          <target state="translated">Crear un nuevo elemento (Ctrl + Shift + N)</target>
         </trans-unit>
         <trans-unit id="NavSearchButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Search</source>
@@ -789,6 +789,10 @@
         <trans-unit id="SettingsAboutOpenLogLocationButton.Content" translate="yes" xml:space="preserve">
           <source>Open Log location</source>
           <target state="translated">Abrir ubicación del archivo de registro (log)</target>
+        </trans-unit>
+        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>New tab (Ctrl + T)</source>
+          <target state="translated">Nueva pestaña (Ctrl + T)</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -499,16 +499,16 @@
           <target state="translated">Esta carpeta está vacía.</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back (Alt + Left arrow)</source>
-          <target state="translated">Atrás (Alt + Flecha izquierda)</target>
+          <source>Back (Alt + Left Arrow)</source>
+          <target state="translated">Atrás (Alt + Flecha Izquierda)</target>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward (Alt + Right arrow)</source>
-          <target state="translated">Adelante (Alt + Flecha derecha)</target>
+          <source>Forward (Alt + Right Arrow)</source>
+          <target state="translated">Adelante (Alt + Flecha Derecha)</target>
         </trans-unit>
         <trans-unit id="NavUpButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Up (Alt + Up Arrow)</source>
-          <target state="translated">Arriba (Alt + Flecha arriba)</target>
+          <target state="translated">Arriba (Alt + Flecha Arriba)</target>
         </trans-unit>
         <trans-unit id="NavRefreshButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Refresh (F5)</source>
@@ -790,7 +790,7 @@
           <source>Open Log location</source>
           <target state="translated">Abrir ubicación del archivo de registro (log)</target>
         </trans-unit>
-        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+        <trans-unit id="TabStripAddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>New tab (Ctrl + T)</source>
           <target state="translated">Nueva pestaña (Ctrl + T)</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -526,24 +526,24 @@
           <target state="new">This folder is empty.</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back</source>
-          <target state="new">Back</target>
+          <source>Back (Alt + Left arrow)</source>
+          <target state="new">Back (Alt + Left arrow)</target>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward</source>
-          <target state="new">Forward</target>
+          <source>Forward (Alt + Right arrow)</source>
+          <target state="new">Forward (Alt + Right arrow)</target>
         </trans-unit>
         <trans-unit id="NavUpButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Up</source>
-          <target state="new">Up</target>
+          <source>Up (Alt + Up Arrow)</source>
+          <target state="new">Up (Alt + Up Arrow)</target>
         </trans-unit>
         <trans-unit id="NavRefreshButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Refresh</source>
-          <target state="new">Refresh</target>
+          <source>Refresh (F5)</source>
+          <target state="new">Refresh (F5)</target>
         </trans-unit>
         <trans-unit id="NavNewItemButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Create a new item</source>
-          <target state="new">Create a new item</target>
+          <source>Create a new item (Ctrl + Shift + N)</source>
+          <target state="new">Create a new item (Ctrl + Shift + N)</target>
         </trans-unit>
         <trans-unit id="NavSearchButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Search</source>
@@ -792,6 +792,10 @@
         <trans-unit id="SettingsAboutOpenLogLocationButton.Content" translate="yes" xml:space="preserve">
           <source>Open Log location</source>
           <target state="new">Open Log location</target>
+        </trans-unit>
+        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>New tab (Ctrl + T)</source>
+          <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -526,12 +526,12 @@
           <target state="new">This folder is empty.</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back (Alt + Left arrow)</source>
-          <target state="new">Back (Alt + Left arrow)</target>
+          <source>Back (Alt + Left Arrow)</source>
+          <target state="new">Back (Alt + Left Arrow)</target>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward (Alt + Right arrow)</source>
-          <target state="new">Forward (Alt + Right arrow)</target>
+          <source>Forward (Alt + Right Arrow)</source>
+          <target state="new">Forward (Alt + Right Arrow)</target>
         </trans-unit>
         <trans-unit id="NavUpButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Up (Alt + Up Arrow)</source>
@@ -793,7 +793,7 @@
           <source>Open Log location</source>
           <target state="new">Open Log location</target>
         </trans-unit>
-        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+        <trans-unit id="TabStripAddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>New tab (Ctrl + T)</source>
           <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -541,12 +541,12 @@
           <target state="translated">Questa cartella è vuota</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back (Alt + Left arrow)</source>
+          <source>Back (Alt + Left Arrow)</source>
           <target state="needs-review-translation">Indietro</target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward (Alt + Right arrow)</source>
+          <source>Forward (Alt + Right Arrow)</source>
           <target state="needs-review-translation">Avanti</target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
@@ -797,7 +797,7 @@
           <source>Open Log location</source>
           <target state="new">Open Log location</target>
         </trans-unit>
-        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+        <trans-unit id="TabStripAddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>New tab (Ctrl + T)</source>
           <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -541,24 +541,29 @@
           <target state="translated">Questa cartella è vuota</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back</source>
-          <target state="translated">Indietro</target>
+          <source>Back (Alt + Left arrow)</source>
+          <target state="needs-review-translation">Indietro</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward</source>
-          <target state="translated">Avanti</target>
+          <source>Forward (Alt + Right arrow)</source>
+          <target state="needs-review-translation">Avanti</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavUpButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Up</source>
-          <target state="translated">Sali</target>
+          <source>Up (Alt + Up Arrow)</source>
+          <target state="needs-review-translation">Sali</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavRefreshButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Refresh</source>
-          <target state="translated">Aggiorna</target>
+          <source>Refresh (F5)</source>
+          <target state="needs-review-translation">Aggiorna</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavNewItemButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Create a new item</source>
-          <target state="translated">Crea un nuovo elemento</target>
+          <source>Create a new item (Ctrl + Shift + N)</source>
+          <target state="needs-review-translation">Crea un nuovo elemento</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavSearchButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Search</source>
@@ -791,6 +796,10 @@
         <trans-unit id="SettingsAboutOpenLogLocationButton.Content" translate="yes" xml:space="preserve">
           <source>Open Log location</source>
           <target state="new">Open Log location</target>
+        </trans-unit>
+        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>New tab (Ctrl + T)</source>
+          <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -502,24 +502,24 @@
           <target state="new">This folder is empty.</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back</source>
-          <target state="new">Back</target>
+          <source>Back (Alt + Left arrow)</source>
+          <target state="new">Back (Alt + Left arrow)</target>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward</source>
-          <target state="new">Forward</target>
+          <source>Forward (Alt + Right arrow)</source>
+          <target state="new">Forward (Alt + Right arrow)</target>
         </trans-unit>
         <trans-unit id="NavUpButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Up</source>
-          <target state="new">Up</target>
+          <source>Up (Alt + Up Arrow)</source>
+          <target state="new">Up (Alt + Up Arrow)</target>
         </trans-unit>
         <trans-unit id="NavRefreshButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Refresh</source>
-          <target state="new">Refresh</target>
+          <source>Refresh (F5)</source>
+          <target state="new">Refresh (F5)</target>
         </trans-unit>
         <trans-unit id="NavNewItemButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Create a new item</source>
-          <target state="new">Create a new item</target>
+          <source>Create a new item (Ctrl + Shift + N)</source>
+          <target state="new">Create a new item (Ctrl + Shift + N)</target>
         </trans-unit>
         <trans-unit id="NavSearchButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Search</source>
@@ -792,6 +792,10 @@
         <trans-unit id="SettingsAboutOpenLogLocationButton.Content" translate="yes" xml:space="preserve">
           <source>Open Log location</source>
           <target state="new">Open Log location</target>
+        </trans-unit>
+        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>New tab (Ctrl + T)</source>
+          <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -502,12 +502,12 @@
           <target state="new">This folder is empty.</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back (Alt + Left arrow)</source>
-          <target state="new">Back (Alt + Left arrow)</target>
+          <source>Back (Alt + Left Arrow)</source>
+          <target state="new">Back (Alt + Left Arrow)</target>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward (Alt + Right arrow)</source>
-          <target state="new">Forward (Alt + Right arrow)</target>
+          <source>Forward (Alt + Right Arrow)</source>
+          <target state="new">Forward (Alt + Right Arrow)</target>
         </trans-unit>
         <trans-unit id="NavUpButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Up (Alt + Up Arrow)</source>
@@ -793,7 +793,7 @@
           <source>Open Log location</source>
           <target state="new">Open Log location</target>
         </trans-unit>
-        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+        <trans-unit id="TabStripAddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>New tab (Ctrl + T)</source>
           <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -502,24 +502,24 @@
           <target state="new">This folder is empty.</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back</source>
-          <target state="new">Back</target>
+          <source>Back (Alt + Left arrow)</source>
+          <target state="new">Back (Alt + Left arrow)</target>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward</source>
-          <target state="new">Forward</target>
+          <source>Forward (Alt + Right arrow)</source>
+          <target state="new">Forward (Alt + Right arrow)</target>
         </trans-unit>
         <trans-unit id="NavUpButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Up</source>
-          <target state="new">Up</target>
+          <source>Up (Alt + Up Arrow)</source>
+          <target state="new">Up (Alt + Up Arrow)</target>
         </trans-unit>
         <trans-unit id="NavRefreshButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Refresh</source>
-          <target state="new">Refresh</target>
+          <source>Refresh (F5)</source>
+          <target state="new">Refresh (F5)</target>
         </trans-unit>
         <trans-unit id="NavNewItemButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Create a new item</source>
-          <target state="new">Create a new item</target>
+          <source>Create a new item (Ctrl + Shift + N)</source>
+          <target state="new">Create a new item (Ctrl + Shift + N)</target>
         </trans-unit>
         <trans-unit id="NavSearchButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Search</source>
@@ -792,6 +792,10 @@
         <trans-unit id="SettingsAboutOpenLogLocationButton.Content" translate="yes" xml:space="preserve">
           <source>Open Log location</source>
           <target state="new">Open Log location</target>
+        </trans-unit>
+        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>New tab (Ctrl + T)</source>
+          <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -502,12 +502,12 @@
           <target state="new">This folder is empty.</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back (Alt + Left arrow)</source>
-          <target state="new">Back (Alt + Left arrow)</target>
+          <source>Back (Alt + Left Arrow)</source>
+          <target state="new">Back (Alt + Left Arrow)</target>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward (Alt + Right arrow)</source>
-          <target state="new">Forward (Alt + Right arrow)</target>
+          <source>Forward (Alt + Right Arrow)</source>
+          <target state="new">Forward (Alt + Right Arrow)</target>
         </trans-unit>
         <trans-unit id="NavUpButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Up (Alt + Up Arrow)</source>
@@ -793,7 +793,7 @@
           <source>Open Log location</source>
           <target state="new">Open Log location</target>
         </trans-unit>
-        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+        <trans-unit id="TabStripAddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>New tab (Ctrl + T)</source>
           <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -499,24 +499,29 @@
           <target state="translated">Эта папка пуста.</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back</source>
-          <target state="translated">Назад</target>
+          <source>Back (Alt + Left arrow)</source>
+          <target state="needs-review-translation">Назад</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward</source>
-          <target state="translated">Вперед</target>
+          <source>Forward (Alt + Right arrow)</source>
+          <target state="needs-review-translation">Вперед</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavUpButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Up</source>
-          <target state="translated">Вверх</target>
+          <source>Up (Alt + Up Arrow)</source>
+          <target state="needs-review-translation">Вверх</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavRefreshButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Refresh</source>
-          <target state="translated">Обновить</target>
+          <source>Refresh (F5)</source>
+          <target state="needs-review-translation">Обновить</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavNewItemButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Create a new item</source>
-          <target state="translated">Создать</target>
+          <source>Create a new item (Ctrl + Shift + N)</source>
+          <target state="needs-review-translation">Создать</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavSearchButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Search</source>
@@ -789,6 +794,10 @@
         <trans-unit id="SettingsAboutOpenLogLocationButton.Content" translate="yes" xml:space="preserve">
           <source>Open Log location</source>
           <target state="translated">Открыть расположение Лог файла</target>
+        </trans-unit>
+        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>New tab (Ctrl + T)</source>
+          <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -499,12 +499,12 @@
           <target state="translated">Эта папка пуста.</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back (Alt + Left arrow)</source>
+          <source>Back (Alt + Left Arrow)</source>
           <target state="needs-review-translation">Назад</target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward (Alt + Right arrow)</source>
+          <source>Forward (Alt + Right Arrow)</source>
           <target state="needs-review-translation">Вперед</target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
@@ -795,7 +795,7 @@
           <source>Open Log location</source>
           <target state="translated">Открыть расположение Лог файла</target>
         </trans-unit>
-        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+        <trans-unit id="TabStripAddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>New tab (Ctrl + T)</source>
           <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -568,12 +568,12 @@
           <target state="translated">இந்தக் கோப்புறை வெறுமையாக உள்ளது</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back (Alt + Left arrow)</source>
+          <source>Back (Alt + Left Arrow)</source>
           <target state="needs-review-translation">பின்</target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward (Alt + Right arrow)</source>
+          <source>Forward (Alt + Right Arrow)</source>
           <target state="needs-review-translation">முன்</target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
@@ -796,7 +796,7 @@
           <source>Open Log location</source>
           <target state="new">Open Log location</target>
         </trans-unit>
-        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+        <trans-unit id="TabStripAddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>New tab (Ctrl + T)</source>
           <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -568,24 +568,29 @@
           <target state="translated">இந்தக் கோப்புறை வெறுமையாக உள்ளது</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back</source>
-          <target state="translated">பின்</target>
+          <source>Back (Alt + Left arrow)</source>
+          <target state="needs-review-translation">பின்</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward</source>
-          <target state="translated">முன்</target>
+          <source>Forward (Alt + Right arrow)</source>
+          <target state="needs-review-translation">முன்</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavUpButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Up</source>
-          <target state="translated">மேல்</target>
+          <source>Up (Alt + Up Arrow)</source>
+          <target state="needs-review-translation">மேல்</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavRefreshButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Refresh</source>
-          <target state="translated">புதுப்பி</target>
+          <source>Refresh (F5)</source>
+          <target state="needs-review-translation">புதுப்பி</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavNewItemButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Create a new item</source>
-          <target state="translated">ஒரு புதிய உருப்படியை உருவாக்கு</target>
+          <source>Create a new item (Ctrl + Shift + N)</source>
+          <target state="needs-review-translation">ஒரு புதிய உருப்படியை உருவாக்கு</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavSearchButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Search</source>
@@ -790,6 +795,10 @@
         <trans-unit id="SettingsAboutOpenLogLocationButton.Content" translate="yes" xml:space="preserve">
           <source>Open Log location</source>
           <target state="new">Open Log location</target>
+        </trans-unit>
+        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>New tab (Ctrl + T)</source>
+          <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -502,24 +502,24 @@
           <target state="new">This folder is empty.</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back</source>
-          <target state="new">Back</target>
+          <source>Back (Alt + Left arrow)</source>
+          <target state="new">Back (Alt + Left arrow)</target>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward</source>
-          <target state="new">Forward</target>
+          <source>Forward (Alt + Right arrow)</source>
+          <target state="new">Forward (Alt + Right arrow)</target>
         </trans-unit>
         <trans-unit id="NavUpButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Up</source>
-          <target state="new">Up</target>
+          <source>Up (Alt + Up Arrow)</source>
+          <target state="new">Up (Alt + Up Arrow)</target>
         </trans-unit>
         <trans-unit id="NavRefreshButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Refresh</source>
-          <target state="new">Refresh</target>
+          <source>Refresh (F5)</source>
+          <target state="new">Refresh (F5)</target>
         </trans-unit>
         <trans-unit id="NavNewItemButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Create a new item</source>
-          <target state="new">Create a new item</target>
+          <source>Create a new item (Ctrl + Shift + N)</source>
+          <target state="new">Create a new item (Ctrl + Shift + N)</target>
         </trans-unit>
         <trans-unit id="NavSearchButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Search</source>
@@ -792,6 +792,10 @@
         <trans-unit id="SettingsAboutOpenLogLocationButton.Content" translate="yes" xml:space="preserve">
           <source>Open Log location</source>
           <target state="new">Open Log location</target>
+        </trans-unit>
+        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>New tab (Ctrl + T)</source>
+          <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -502,12 +502,12 @@
           <target state="new">This folder is empty.</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back (Alt + Left arrow)</source>
-          <target state="new">Back (Alt + Left arrow)</target>
+          <source>Back (Alt + Left Arrow)</source>
+          <target state="new">Back (Alt + Left Arrow)</target>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward (Alt + Right arrow)</source>
-          <target state="new">Forward (Alt + Right arrow)</target>
+          <source>Forward (Alt + Right Arrow)</source>
+          <target state="new">Forward (Alt + Right Arrow)</target>
         </trans-unit>
         <trans-unit id="NavUpButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Up (Alt + Up Arrow)</source>
@@ -793,7 +793,7 @@
           <source>Open Log location</source>
           <target state="new">Open Log location</target>
         </trans-unit>
-        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+        <trans-unit id="TabStripAddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>New tab (Ctrl + T)</source>
           <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -499,24 +499,29 @@
           <target state="translated">Ця папка порожня.</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back</source>
-          <target state="translated">Назад</target>
+          <source>Back (Alt + Left arrow)</source>
+          <target state="needs-review-translation">Назад</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward</source>
-          <target state="translated">Вперед</target>
+          <source>Forward (Alt + Right arrow)</source>
+          <target state="needs-review-translation">Вперед</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavUpButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Up</source>
-          <target state="translated">Вгору</target>
+          <source>Up (Alt + Up Arrow)</source>
+          <target state="needs-review-translation">Вгору</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavRefreshButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Refresh</source>
-          <target state="translated">Оновити</target>
+          <source>Refresh (F5)</source>
+          <target state="needs-review-translation">Оновити</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavNewItemButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Create a new item</source>
-          <target state="translated">Створити</target>
+          <source>Create a new item (Ctrl + Shift + N)</source>
+          <target state="needs-review-translation">Створити</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavSearchButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Search</source>
@@ -789,6 +794,10 @@
         <trans-unit id="SettingsAboutOpenLogLocationButton.Content" translate="yes" xml:space="preserve">
           <source>Open Log location</source>
           <target state="translated">Відкрити розташування Лог файлу</target>
+        </trans-unit>
+        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>New tab (Ctrl + T)</source>
+          <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -499,12 +499,12 @@
           <target state="translated">Ця папка порожня.</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back (Alt + Left arrow)</source>
+          <source>Back (Alt + Left Arrow)</source>
           <target state="needs-review-translation">Назад</target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward (Alt + Right arrow)</source>
+          <source>Forward (Alt + Right Arrow)</source>
           <target state="needs-review-translation">Вперед</target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
@@ -795,7 +795,7 @@
           <source>Open Log location</source>
           <target state="translated">Відкрити розташування Лог файлу</target>
         </trans-unit>
-        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+        <trans-unit id="TabStripAddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>New tab (Ctrl + T)</source>
           <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -502,24 +502,29 @@
           <target state="translated">该文件夹为空。</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back</source>
-          <target state="translated">返回</target>
+          <source>Back (Alt + Left arrow)</source>
+          <target state="needs-review-translation">返回</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward</source>
-          <target state="translated">前进</target>
+          <source>Forward (Alt + Right arrow)</source>
+          <target state="needs-review-translation">前进</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavUpButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Up</source>
-          <target state="translated">上移</target>
+          <source>Up (Alt + Up Arrow)</source>
+          <target state="needs-review-translation">上移</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavRefreshButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Refresh</source>
-          <target state="translated">刷新</target>
+          <source>Refresh (F5)</source>
+          <target state="needs-review-translation">刷新</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavNewItemButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Create a new item</source>
-          <target state="translated">新建项目</target>
+          <source>Create a new item (Ctrl + Shift + N)</source>
+          <target state="needs-review-translation">新建项目</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavSearchButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>Search</source>
@@ -792,6 +797,10 @@
         <trans-unit id="SettingsAboutOpenLogLocationButton.Content" translate="yes" xml:space="preserve">
           <source>Open Log location</source>
           <target state="new">Open Log location</target>
+        </trans-unit>
+        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+          <source>New tab (Ctrl + T)</source>
+          <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>
       </group>
     </body>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -502,12 +502,12 @@
           <target state="translated">该文件夹为空。</target>
         </trans-unit>
         <trans-unit id="NavBackButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Back (Alt + Left arrow)</source>
+          <source>Back (Alt + Left Arrow)</source>
           <target state="needs-review-translation">返回</target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="NavForwardButton.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
-          <source>Forward (Alt + Right arrow)</source>
+          <source>Forward (Alt + Right Arrow)</source>
           <target state="needs-review-translation">前进</target>
           <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
@@ -798,7 +798,7 @@
           <source>Open Log location</source>
           <target state="new">Open Log location</target>
         </trans-unit>
-        <trans-unit id="AddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
+        <trans-unit id="TabStripAddNewTab.ToolTipService.ToolTip" translate="yes" xml:space="preserve">
           <source>New tab (Ctrl + T)</source>
           <target state="new">New tab (Ctrl + T)</target>
         </trans-unit>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -705,7 +705,7 @@
   <data name="SettingsAboutOpenLogLocationButton.Content" xml:space="preserve">
     <value>Open Log location</value>
   </data>
-  <data name="AddNewTab.ToolTipService.ToolTip" xml:space="preserve">
+  <data name="TabStripAddNewTab.ToolTipService.ToolTip" xml:space="preserve">
     <value>New tab (Ctrl + T)</value>
   </data>
 </root>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -541,10 +541,10 @@
     <value>This folder is empty.</value>
   </data>
   <data name="NavBackButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Back (Alt + Left arrow)</value>
+    <value>Back (Alt + Left Arrow)</value>
   </data>
   <data name="NavForwardButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Forward (Alt + Right arrow)</value>
+    <value>Forward (Alt + Right Arrow)</value>
   </data>
   <data name="NavUpButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Up (Alt + Up Arrow)</value>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -541,19 +541,19 @@
     <value>This folder is empty.</value>
   </data>
   <data name="NavBackButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Back</value>
+    <value>Back (Alt + Left arrow)</value>
   </data>
   <data name="NavForwardButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Forward</value>
+    <value>Forward (Alt + Right arrow)</value>
   </data>
   <data name="NavUpButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Up</value>
+    <value>Up (Alt + Up Arrow)</value>
   </data>
   <data name="NavRefreshButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Refresh</value>
+    <value>Refresh (F5)</value>
   </data>
   <data name="NavNewItemButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Create a new item</value>
+    <value>Create a new item (Ctrl + Shift + N)</value>
   </data>
   <data name="NavSearchButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Search</value>
@@ -694,15 +694,18 @@
     <value>Open With</value>
   </data>
   <data name="FileNameTeachingTip.Subtitle" xml:space="preserve">
-    <value>The item name must not contain the following characters: \ / : * ? &quot; &lt; &gt; |</value>
+    <value>The item name must not contain the following characters: \ / : * ? " &lt; &gt; |</value>
   </data>
   <data name="FileNameTeachingTip.CloseButtonContent" xml:space="preserve">
     <value>OK</value>
   </data>
-   <data name="RenameDialogSymbolsTip.Text" xml:space="preserve">
-    <value>The item name must not contain the following characters: \ / : * ? &quot; &lt; &gt; |</value>
+  <data name="RenameDialogSymbolsTip.Text" xml:space="preserve">
+    <value>The item name must not contain the following characters: \ / : * ? " &lt; &gt; |</value>
   </data>
   <data name="SettingsAboutOpenLogLocationButton.Content" xml:space="preserve">
     <value>Open Log location</value>
+  </data>
+  <data name="AddNewTab.ToolTipService.ToolTip" xml:space="preserve">
+    <value>New tab (Ctrl + T)</value>
   </data>
 </root>

--- a/Files/Strings/es-ES/Resources.resw
+++ b/Files/Strings/es-ES/Resources.resw
@@ -382,13 +382,13 @@
     <value>Esta carpeta está vacía.</value>
   </data>
   <data name="NavBackButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Atrás (Alt + Flecha izquierda)</value>
+    <value>Atrás (Alt + Flecha Izquierda)</value>
   </data>
   <data name="NavForwardButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Adelante (Alt + Flecha derecha)</value>
+    <value>Adelante (Alt + Flecha Derecha)</value>
   </data>
   <data name="NavUpButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Arriba (Alt + Flecha arriba)</value>
+    <value>Arriba (Alt + Flecha Arriba)</value>
   </data>
   <data name="NavRefreshButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Actualizar (F5)</value>
@@ -600,7 +600,7 @@
   <data name="SettingsAboutOpenLogLocationButton.Content" xml:space="preserve">
     <value>Abrir ubicación del archivo de registro (log)</value>
   </data>
-  <data name="AddNewTab.ToolTipService.ToolTip" xml:space="preserve">
+  <data name="TabStripAddNewTab.ToolTipService.ToolTip" xml:space="preserve">
     <value>Nueva pestaña (Ctrl + T)</value>
   </data>
 </root>

--- a/Files/Strings/es-ES/Resources.resw
+++ b/Files/Strings/es-ES/Resources.resw
@@ -382,19 +382,19 @@
     <value>Esta carpeta está vacía.</value>
   </data>
   <data name="NavBackButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Atrás</value>
+    <value>Atrás (Alt + Flecha izquierda)</value>
   </data>
   <data name="NavForwardButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Adelante</value>
+    <value>Adelante (Alt + Flecha derecha)</value>
   </data>
   <data name="NavUpButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Arriba</value>
+    <value>Arriba (Alt + Flecha arriba)</value>
   </data>
   <data name="NavRefreshButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Actualizar</value>
+    <value>Actualizar (F5)</value>
   </data>
   <data name="NavNewItemButton.ToolTipService.ToolTip" xml:space="preserve">
-    <value>Crear un nuevo elemento</value>
+    <value>Crear un nuevo elemento (Ctrl + Shift + N)</value>
   </data>
   <data name="NavSearchButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Búsqueda</value>
@@ -599,5 +599,8 @@
   </data>
   <data name="SettingsAboutOpenLogLocationButton.Content" xml:space="preserve">
     <value>Abrir ubicación del archivo de registro (log)</value>
+  </data>
+  <data name="AddNewTab.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Nueva pestaña (Ctrl + T)</value>
   </data>
 </root>

--- a/Files/UserControls/NavigationToolbar/ModernNavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar/ModernNavigationToolbar.xaml
@@ -536,7 +536,7 @@
                 FontFamily="Segoe MDL2 Assets"
                 IsEnabled="{x:Bind local1:App.CurrentInstance.NavigationToolbar.CanGoBack}"
                 Style="{StaticResource ToolBarButtonStyle}"
-                ToolTipService.ToolTip="Back (Alt + Left arrow)">
+                ToolTipService.ToolTip="Back (Alt + Left Arrow)">
                 <Button.Content>
                     &#xE72B;
                 </Button.Content>
@@ -559,7 +559,7 @@
                 FontFamily="Segoe MDL2 Assets"
                 IsEnabled="{x:Bind local1:App.CurrentInstance.NavigationToolbar.CanGoForward}"
                 Style="{StaticResource ToolBarButtonStyle}"
-                ToolTipService.ToolTip="Forward (Alt + Right arrow)">
+                ToolTipService.ToolTip="Forward (Alt + Right Arrow)">
                 <Button.Content>
                     &#xE72A;
                 </Button.Content>

--- a/Files/UserControls/NavigationToolbar/ModernNavigationToolbar.xaml
+++ b/Files/UserControls/NavigationToolbar/ModernNavigationToolbar.xaml
@@ -536,7 +536,7 @@
                 FontFamily="Segoe MDL2 Assets"
                 IsEnabled="{x:Bind local1:App.CurrentInstance.NavigationToolbar.CanGoBack}"
                 Style="{StaticResource ToolBarButtonStyle}"
-                ToolTipService.ToolTip="Back">
+                ToolTipService.ToolTip="Back (Alt + Left arrow)">
                 <Button.Content>
                     &#xE72B;
                 </Button.Content>
@@ -559,7 +559,7 @@
                 FontFamily="Segoe MDL2 Assets"
                 IsEnabled="{x:Bind local1:App.CurrentInstance.NavigationToolbar.CanGoForward}"
                 Style="{StaticResource ToolBarButtonStyle}"
-                ToolTipService.ToolTip="Forward">
+                ToolTipService.ToolTip="Forward (Alt + Right arrow)">
                 <Button.Content>
                     &#xE72A;
                 </Button.Content>
@@ -580,7 +580,7 @@
                 CornerRadius="2"
                 FontFamily="Segoe MDL2 Assets"
                 Style="{StaticResource ToolBarButtonStyle}"
-                ToolTipService.ToolTip="Up"
+                ToolTipService.ToolTip="Up (Alt + Up Arrow)"
                 Visibility="Visible">
                 <Button.Content>
                     &#xE74A;
@@ -602,7 +602,7 @@
                 CornerRadius="2"
                 FontFamily="Segoe MDL2 Assets"
                 Style="{StaticResource ToolBarButtonStyle}"
-                ToolTipService.ToolTip="Refresh">
+                ToolTipService.ToolTip="Refresh (F5)">
                 <Button.Content>
                     &#xE72C;
                 </Button.Content>
@@ -698,7 +698,7 @@
                 FontFamily="Segoe MDL2 Assets"
                 IsEnabled="{x:Bind local1:App.InteractionViewModel.IsPageTypeNotRecycleBin, Mode=OneWay}"
                 Style="{StaticResource ToolBarButtonStyle}"
-                ToolTipService.ToolTip="Create a new item"
+                ToolTipService.ToolTip="Create a new item (Ctrl + Shift + N)"
                 Visibility="Visible">
                 <Button.Content>
                     <FontIcon FontSize="14" Glyph="&#xE710;" />

--- a/Files/Views/InstanceTabsView.xaml
+++ b/Files/Views/InstanceTabsView.xaml
@@ -547,7 +547,7 @@
                         </Grid.ColumnDefinitions>
                         <Button
                             x:Name="AddTabButton"
-                            x:Uid="AddNewTab"
+                            x:Uid="TabStripAddNewTab"
                             Width="28"
                             Height="28"
                             Margin="2,7,0,0"

--- a/Files/Views/InstanceTabsView.xaml
+++ b/Files/Views/InstanceTabsView.xaml
@@ -547,11 +547,13 @@
                         </Grid.ColumnDefinitions>
                         <Button
                             x:Name="AddTabButton"
+                            x:Uid="AddNewTab"
                             Width="28"
                             Height="28"
                             Margin="2,7,0,0"
                             Background="Transparent"
-                            Click="AddTabButton_Click">
+                            Click="AddTabButton_Click"
+                            ToolTipService.ToolTip="New tab (Ctrl + T)" >
                             <Button.Content>
                                 <FontIcon FontSize="10" Glyph="&#xE710;" />
                             </Button.Content>


### PR DESCRIPTION
- A tooltip was also added for the add tab button (@yaichenbaum take a look at the Uid of this button)
-------------------------------
- Back (Alt + Left Arrow)
- Forward (Alt + Right Arrow)
- Up (Alt + Up Arrow)
- Refresh (F5)
- Create a new item (Ctrl + Shift + N)
- New tab (Ctrl + T)