### PR TITLE
Terminal: Use path as terminal identifier

### DIFF
--- a/Files/Assets/terminal/terminal.json
+++ b/Files/Assets/terminal/terminal.json
@@ -1,9 +1,8 @@
 ﻿{
   "version": 1,
-  "defaultTerminalId": 1,
+  "defaultTerminalPath": "cmd.exe",
   "terminals": [
     {
-      "id": 1,
       "name": "CMD",
       "path": "cmd.exe",
       "arguments": "/k \"cd /d {0} && title Command Prompt\"",
@@ -11,14 +10,12 @@
     }
     /*
     {
-      "id": 2,
       "name": "PowerShell Core 6",
       "path": "pwsh.exe",
       "arguments": "-WorkingDirectory \"{0}\"",
       "icon": ""
     },
     {
-      "id": 3,
       "name": "Windows Terminal",
       "path": "wt.exe",
       "arguments": "-d \"{0}\"",

--- a/Files/DataModels/TerminalFileModel.cs
+++ b/Files/DataModels/TerminalFileModel.cs
@@ -12,27 +12,33 @@ namespace Files.DataModels
         [JsonProperty("version")]
         public int Version { get; set; }
 
-        [JsonProperty("defaultTerminalId")]
-        public int DefaultTerminalId { get; set; }
+        [JsonProperty("defaultTerminalPath")]
+        public string DefaultTerminalPath { get; set; }
 
         [JsonProperty("terminals")]
         public List<TerminalModel> Terminals { get; set; } = new List<TerminalModel>();
 
         public TerminalModel GetDefaultTerminal()
         {
-            if (DefaultTerminalId != 0)
+            TerminalModel terminal = Terminals.FirstOrDefault(x => x.Path.Equals(DefaultTerminalPath, StringComparison.OrdinalIgnoreCase));
+            if (terminal != null)
             {
-                return Terminals.Single(x => x.Id == DefaultTerminalId);
+                return terminal;
             }
+            else
+            {
+                ResetToDefaultTerminal();
+            }
+
             return Terminals.First();
         }
 
         public void ResetToDefaultTerminal()
         {
-            DefaultTerminalId = 1;
+            DefaultTerminalPath = "CMD";
         }
 
-        public async Task<bool> AddTerminal(TerminalModel terminal, string packageName)
+        public async Task<bool> AddOrRemoveTerminal(TerminalModel terminal, string packageName)
         {
             bool isChanged = false;
             bool isInstalled = await PackageHelper.IsAppInstalledAsync(packageName);
@@ -44,8 +50,12 @@ namespace Files.DataModels
             }
             else if (!isInstalled)
             {
+                if (DefaultTerminalPath.Equals(terminal.Path, StringComparison.OrdinalIgnoreCase))
+                {
+                    ResetToDefaultTerminal();
+                }
                 Terminals.Remove(Terminals.FirstOrDefault(x => x.Path.Equals(terminal.Path, StringComparison.OrdinalIgnoreCase)));
-                ResetToDefaultTerminal();
+
                 isChanged = true;
             }
             return isChanged;

--- a/Files/DataModels/TerminalFileModel.cs
+++ b/Files/DataModels/TerminalFileModel.cs
@@ -35,7 +35,7 @@ namespace Files.DataModels
 
         public void ResetToDefaultTerminal()
         {
-            DefaultTerminalPath = "CMD";
+            DefaultTerminalPath = "cmd.exe";
         }
 
         public async Task<bool> AddOrRemoveTerminal(TerminalModel terminal, string packageName)

--- a/Files/DataModels/TerminalModel.cs
+++ b/Files/DataModels/TerminalModel.cs
@@ -4,9 +4,6 @@ namespace Files.DataModels
 {
     public class TerminalModel
     {
-        [JsonProperty("id")]
-        public int Id { get; set; }
-
         [JsonProperty("name")]
         public string Name { get; set; }
 

--- a/Files/View Models/SettingsViewModel.cs
+++ b/Files/View Models/SettingsViewModel.cs
@@ -347,24 +347,22 @@ namespace Files.View_Models
 
             var windowsTerminal = new TerminalModel()
             {
-                Id = TerminalsModel.Terminals.Count + 1,
                 Name = "Windows Terminal",
                 Path = "wt.exe",
-                Arguments = "-d {0}",
+                Arguments = "-d \"{0}\"",
                 Icon = ""
             };
 
             var fluentTerminal = new TerminalModel()
             {
-                Id = TerminalsModel.Terminals.Count + 1,
                 Name = "Fluent Terminal",
                 Path = "flute.exe",
                 Arguments = "new \"{0}\"",
                 Icon = ""
             };
 
-            bool isWindowsTerminalAddedOrRemoved = await TerminalsModel.AddTerminal(windowsTerminal, "Microsoft.WindowsTerminal_8wekyb3d8bbwe");
-            bool isFluentTerminalAddedOrRemoved = await TerminalsModel.AddTerminal(fluentTerminal, "53621FSApps.FluentTerminal_87x1pks76srcp");
+            bool isWindowsTerminalAddedOrRemoved = await TerminalsModel.AddOrRemoveTerminal(windowsTerminal, "Microsoft.WindowsTerminal_8wekyb3d8bbwe");
+            bool isFluentTerminalAddedOrRemoved = await TerminalsModel.AddOrRemoveTerminal(fluentTerminal, "53621FSApps.FluentTerminal_87x1pks76srcp");
             if (isWindowsTerminalAddedOrRemoved || isFluentTerminalAddedOrRemoved)
             {
                 await FileIO.WriteTextAsync(TerminalsModelFile, JsonConvert.SerializeObject(TerminalsModel, Formatting.Indented));

--- a/Files/Views/SettingsPages/Preferences.xaml.cs
+++ b/Files/Views/SettingsPages/Preferences.xaml.cs
@@ -52,7 +52,7 @@ namespace Files.SettingsPages
 
             var selectedTerminal = (TerminalModel)comboBox.SelectedItem;
 
-            App.AppSettings.TerminalsModel.DefaultTerminalId = selectedTerminal.Id;
+            App.AppSettings.TerminalsModel.DefaultTerminalPath = selectedTerminal.Path;
 
             SaveTerminalSettings();
         }


### PR DESCRIPTION
Fixed issue when terminal Id hasn't been found