### PR TITLE
[Fixed]   #1034 Multi-Windows Cut Copy crash

### DIFF
--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -849,7 +849,14 @@ namespace Files.Interacts
             }
             dataPackage.SetStorageItems(items);
             Clipboard.SetContent(dataPackage);
-            Clipboard.Flush();
+            try
+            {
+                Clipboard.Flush();
+            }
+            catch
+            {
+                dataPackage = null;
+            }
         }
 
         public string CopySourcePath;
@@ -887,7 +894,13 @@ namespace Files.Interacts
             {
                 dataPackage.SetStorageItems(items);
                 Clipboard.SetContent(dataPackage);
-                Clipboard.Flush();
+                try
+                {
+                    Clipboard.Flush();
+                }
+                catch {
+                    dataPackage = null;
+                }
             }
         }
 


### PR DESCRIPTION
This happens because when a new window is created  "Clipboard.Flush()" can't able to release the datapackage it's holding.

Solved it based on the StackTrace Below:

```
CloseClipboard Failed (Exception from HRESULT: 0x800401D4 (CLIPBRD_E_CANT_CLOSE))|System.Exception: CloseClipboard Failed (Exception from HRESULT: 0x800401D4 (CLIPBRD_E_CANT_CLOSE))
   at Windows.ApplicationModel.DataTransfer.Clipboard.Flush()
   at Files.Interacts.Interaction.CopyItem_ClickAsync(Object sender, RoutedEventArgs e)
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.<>c.<ThrowAsync>b__7_0(Object state)
   at System.Threading.WinRTSynchronizationContextBase.Invoker.InvokeCore()
   at Windows.ApplicationModel.Core.UnhandledError.Propagate()
   at Microsoft.AppCenter.Utils.ApplicationLifecycleHelper.<.ctor>b__17_1(Object sender, UnhandledErrorDetectedEventArgs eventArgs)
```