### PR TITLE
Cancel previous watcher

### DIFF
--- a/Files/Helpers/NativeDirectoryChangesHelper.cs
+++ b/Files/Helpers/NativeDirectoryChangesHelper.cs
@@ -20,6 +20,9 @@ namespace Files.Helpers
         [DllImport("api-ms-win-core-io-l1-1-1.dll")]
         public static extern bool CancelIo(IntPtr hFile);
 
+        [DllImport("api-ms-win-core-io-l1-1-1.dll")]
+        public static extern bool CancelIoEx(IntPtr hFile, IntPtr lpOverlapped);
+
         [DllImport("api-ms-win-core-synch-l1-2-0.dll")]
         public static extern uint WaitForMultipleObjectsEx(uint nCount, IntPtr[] lpHandles, bool bWaitAll, uint dwMilliseconds, bool bAlertable);
 

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -666,6 +666,7 @@ namespace Files.Filesystem
 
                 if (aWatcherAction.Status != AsyncStatus.Started)
                 {
+                    aWatcherAction = null;  // Prevent duplicate execution of this block
                     Debug.WriteLine("watcher canceled");
                     CancelIoEx(hWatchDir, IntPtr.Zero);
                     Debug.WriteLine("watcher handle closed");


### PR DESCRIPTION
Proposal for #1001
\- Use `CancelIoEx` to cancel previous watcher: watcher is started on a background thread so `CancelIo` has no effect.
\- Close overlapped.hEvent handle
\- Close hWatchDir handle