### PR TITLE
Improved support for opening multiple files at a time

### DIFF
--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -342,6 +342,10 @@ namespace FilesFullTrust
                     {
                         // Cannot open file (e.g DLL)
                     }
+                    catch (ArgumentException)
+                    {
+                        // Cannot open file (e.g DLL)
+                    }
                 }
             }
         }

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -309,7 +309,9 @@ namespace FilesFullTrust
                         }
                         else
                         {
-                            var groups = split.GroupBy(x => new { Dir = Path.GetDirectoryName(x), Ext = Path.GetExtension(x).ToLowerInvariant() });
+                            var groups = split.GroupBy(x => new {
+                                Dir = Path.GetDirectoryName(x),
+                                Prog = Win32API.GetFileAssociation(x).Result ?? Path.GetExtension(x) });
                             foreach (var group in groups)
                             {
                                 if (!group.Any()) continue;
@@ -324,7 +326,7 @@ namespace FilesFullTrust
                                     pici.lpVerb = Vanara.PInvoke.Shell32.CMDSTR_OPEN;
                                     pici.nShow = Vanara.PInvoke.ShowWindowCommand.SW_SHOW;
                                     pici.cbSize = (uint)Marshal.SizeOf(pici);
-                                    menu.InvokeCommand(pici);                                    
+                                    menu.InvokeCommand(pici);
                                 }
                                 finally
                                 {

--- a/Files.Launcher/Win32API.cs
+++ b/Files.Launcher/Win32API.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Vanara.Windows.Shell;
@@ -18,6 +19,21 @@ namespace FilesFullTrust
             public uint cbSize;
             public long i64Size;
             public long i64NumItems;
+        }
+
+        [DllImport("shell32.dll", CharSet = CharSet.Ansi)]
+        public static extern IntPtr FindExecutable(string lpFile, string lpDirectory, [Out] System.Text.StringBuilder lpResult);
+
+        public static async System.Threading.Tasks.Task<string> GetFileAssociation(string filename)
+        {
+            // Find UWP apps
+            var uwp_apps = await Windows.System.Launcher.FindFileHandlersAsync(System.IO.Path.GetExtension(filename));
+            if (uwp_apps.Any()) return uwp_apps.First().PackageFamilyName;
+            // Find desktop apps
+            var lpResult = new System.Text.StringBuilder();
+            var hResult = FindExecutable(filename, null, lpResult);
+            if (hResult.ToInt64() > 32) return lpResult.ToString();
+            return null;
         }
 
         public enum PropertyReturnType


### PR DESCRIPTION
Currently if you click [enter] after selecting multiple e.g. ".mp3" files only the last one will be played in the associated program (e.g. Groove Music). Same goes with multiple picture files, etc..
This PR fixes this.
Fixes #1057