### PR TITLE
Improve performance on selection operations

### DIFF
--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Helpers\NaturalStringComparer.cs" />
     <Compile Include="Helpers\PackageHelper.cs" />
     <Compile Include="Helpers\StringExtensions.cs" />
+    <Compile Include="Helpers\BulkObservableCollection.cs" />
     <Compile Include="Helpers\ThemeHelper.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="ResourceController.cs" />

--- a/Files/Helpers/BulkObservableCollection.cs
+++ b/Files/Helpers/BulkObservableCollection.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+
+namespace Files.Helpers
+{
+    public class BulkObservableCollection<T> : ObservableCollection<T>
+    {
+        private bool _isBlukOperationStarted;
+        public void BeginBulkOperation()
+        {
+            _isBlukOperationStarted = true;
+        }
+
+        protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+        {
+            if (!_isBlukOperationStarted)
+            {
+                base.OnCollectionChanged(e);
+            }
+        }
+
+        public void EndBulkOperation()
+        {
+            base.OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            _isBlukOperationStarted = false;
+        }
+    }
+}

--- a/Files/UserControls/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/UserControls/LayoutModes/GenericFileBrowser.xaml.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
+using System.Reflection;
 using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
@@ -22,6 +23,7 @@ namespace Files
     {
         private string oldItemName;
         private DataGridColumn _sortedColumn;
+        private static readonly MethodInfo SelectAllMethod = typeof(DataGrid).GetMethod("SelectAll", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Instance);
 
         public DataGridColumn SortedColumn
         {
@@ -105,7 +107,6 @@ namespace Files
         public override void SetSelectedItemsOnUi(List<ListedItem> items)
         {
             ClearSelection();
-
             foreach (ListedItem item in items)
             {
                 AllView.SelectedItems.Add(item);
@@ -114,7 +115,7 @@ namespace Files
 
         public override void SelectAllItems()
         {
-            SetSelectedItemsOnUi(AssociatedViewModel.FilesAndFolders.ToList());
+            SelectAllMethod.Invoke(AllView, null);
         }
 
         public override void InvertSelection()

--- a/Files/UserControls/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/UserControls/LayoutModes/GenericFileBrowser.xaml.cs
@@ -411,7 +411,9 @@ namespace Files
         private async void Icon_EffectiveViewportChanged(FrameworkElement sender, EffectiveViewportChangedEventArgs args)
         {
             var parentRow = Interacts.Interaction.FindParent<DataGridRow>(sender);
-            if ((!(parentRow.DataContext as ListedItem).ItemPropertiesInitialized) && (args.BringIntoViewDistanceX < sender.ActualHeight))
+            if (parentRow.DataContext is ListedItem item && 
+                !item.ItemPropertiesInitialized && 
+                args.BringIntoViewDistanceX < sender.ActualHeight)
             {
                 await Window.Current.CoreWindow.Dispatcher.RunIdleAsync((e) =>
                 {

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -40,7 +40,7 @@ namespace Files.Filesystem
         public ReadOnlyObservableCollection<ListedItem> FilesAndFolders { get; }
         public ListedItem CurrentFolder { get; private set; }
         public CollectionViewSource viewSource;
-        public ObservableCollection<ListedItem> _filesAndFolders;
+        public BulkObservableCollection<ListedItem> _filesAndFolders;
         private CancellationTokenSource _addFilesCTS, _semaphoreCTS;
         private StorageFolder _rootFolder;
         public event PropertyChangedEventHandler PropertyChanged;
@@ -271,7 +271,7 @@ namespace Files.Filesystem
 
         public ItemViewModel()
         {
-            _filesAndFolders = new ObservableCollection<ListedItem>();
+            _filesAndFolders = new BulkObservableCollection<ListedItem>();
             FilesAndFolders = new ReadOnlyObservableCollection<ListedItem>(_filesAndFolders);
             _addFilesCTS = new CancellationTokenSource();
             _semaphoreCTS = new CancellationTokenSource();
@@ -451,6 +451,8 @@ namespace Files.Filesystem
             orderedList = ordered.ToList();
 
             List<ListedItem> originalList = _filesAndFolders.ToList();
+
+            _filesAndFolders.BeginBulkOperation();
             for (var i = 0; i < originalList.Count; i++)
             {
                 if (originalList[i] != orderedList[i])
@@ -459,6 +461,7 @@ namespace Files.Filesystem
                     _filesAndFolders.Insert(i, orderedList[i]);
                 }
             }
+            _filesAndFolders.EndBulkOperation();
         }
 
         private bool _isLoadingItems = false;


### PR DESCRIPTION
- Added BulkObservableCollection: support bulk operations based on ObservableCollection, and make sorting process faster
- Optimize SelectAll: call non-public method `DataGrid.SelectAll()` to make Select All operation as fast as Ctrl+A

A further question:
How to optimize Invert Selection? DataGrid used `SetRowsSelection()` internally for fast selection operation, I think we can make it use for implementing faster Invert Selection.

https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/4aca25975f3cec90d4f86d5b5239aa6bc185880b/Microsoft.Toolkit.Uwp.UI.Controls.DataGrid/DataGrid/DataGridRows.cs#L797