### PR TITLE
Bug fixes for handling network path

### DIFF
--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -306,11 +306,12 @@ namespace Files.Filesystem
 
             // If path is found to not be a library
             pathComponents = WorkingDirectory.Split("\\", StringSplitOptions.RemoveEmptyEntries).ToList();
+
             int index = 0;
+            string tag = "";
             foreach (string s in pathComponents)
             {
                 string componentLabel = null;
-                string tag = "";
                 if (s.StartsWith(App.AppSettings.RecycleBinPath))
                 {
                     // Handle the recycle bin: use the localized folder name
@@ -343,7 +344,7 @@ namespace Files.Filesystem
                 else
                 {
                     componentLabel = s;
-                    foreach (string part in pathComponents.GetRange(0, index + 1))
+                    foreach (string part in pathComponents.GetRange(index, 1))
                     {
                         tag = tag + part + @"\";
                     }

--- a/Files/Views/InstanceTabsView.xaml.cs
+++ b/Files/Views/InstanceTabsView.xaml.cs
@@ -342,6 +342,10 @@ namespace Files
 
         public static string NormalizePath(string path)
         {
+            if (string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
             if (path.StartsWith("\\\\"))
             {
                 return path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar).ToUpperInvariant();


### PR DESCRIPTION
Fixes:
- Tag will lost prefixed `\\` if it's a network path, and will crash if try to navigate by clicking PathItemBox
- Path.GetRootPath() may return null or empty string, which leads to crash in NormalizePath()