### PR TITLE
Fix incorrect item size value

### DIFF
--- a/Files/Filesystem/DriveItem.cs
+++ b/Files/Filesystem/DriveItem.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ByteSizeLib;
+using System;
 using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.UI.Xaml;
@@ -11,8 +12,9 @@ namespace Files.Filesystem
         public string Text { get; set; }
         public string Path { get; set; }
         public NavigationControlItemType ItemType { get; set; } = NavigationControlItemType.Drive;
-        public ulong MaxSpace { get; set; } = 0;
-        public ulong SpaceUsed { get; set; } = 0;
+        public ByteSize MaxSpace { get; set; }
+        public ByteSize FreeSpace { get; set; }
+        public ByteSize SpaceUsed { get; set; }
         public string SpaceText { get; set; }
         public Visibility ItemVisibility { get; set; } = Visibility.Visible;
 
@@ -45,13 +47,15 @@ namespace Files.Filesystem
             }).Result;
 
             try
-            {
-                SpaceUsed = MaxSpace -
-                            Convert.ToUInt64(ByteSizeLib.ByteSize.FromBytes((ulong)properties["System.FreeSpace"]).GigaBytes);
-                MaxSpace = Convert.ToUInt64(ByteSizeLib.ByteSize.FromBytes((ulong)properties["System.Capacity"]).GigaBytes);
-                SpaceText = String.Format(ResourceController.GetTranslation("DriveFreeSpaceAndCapacity"),
-                    ByteSizeLib.ByteSize.FromBytes((ulong)properties["System.FreeSpace"]).ToString(),
-                    ByteSizeLib.ByteSize.FromBytes((ulong)properties["System.Capacity"]).ToString());
+            {           
+                MaxSpace = ByteSize.FromBytes((ulong)properties["System.Capacity"]);
+                FreeSpace = ByteSize.FromBytes((ulong)properties["System.FreeSpace"]);
+
+                SpaceUsed = MaxSpace - FreeSpace;
+                SpaceText = string.Format(
+                    ResourceController.GetTranslation("DriveFreeSpaceAndCapacity"),
+                    FreeSpace.ToBinaryString(),
+                    MaxSpace.ToBinaryString());
             }
             catch (NullReferenceException)
             {

--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -837,6 +837,10 @@
           <source>Open properties in Multiple Windows</source>
           <target state="new">Open properties in Multiple Windows</target>
         </trans-unit>
+        <trans-unit id="ItemSizeBytes" translate="yes" xml:space="preserve">
+          <source>bytes</source>
+          <target state="new">bytes</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -830,6 +830,10 @@
           <source>Open properties in Multiple Windows</source>
           <target state="translated">Ver propiedades de multiples elementos seleccionados</target>
         </trans-unit>
+        <trans-unit id="ItemSizeBytes" translate="yes" xml:space="preserve">
+          <source>bytes</source>
+          <target state="new">bytes</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -833,6 +833,10 @@
           <source>Open properties in Multiple Windows</source>
           <target state="new">Open properties in Multiple Windows</target>
         </trans-unit>
+        <trans-unit id="ItemSizeBytes" translate="yes" xml:space="preserve">
+          <source>bytes</source>
+          <target state="new">bytes</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.it-IT.xlf
+++ b/Files/MultilingualResources/Files.it-IT.xlf
@@ -837,6 +837,10 @@
           <source>Open properties in Multiple Windows</source>
           <target state="new">Open properties in Multiple Windows</target>
         </trans-unit>
+        <trans-unit id="ItemSizeBytes" translate="yes" xml:space="preserve">
+          <source>bytes</source>
+          <target state="new">bytes</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.ja-JP.xlf
+++ b/Files/MultilingualResources/Files.ja-JP.xlf
@@ -830,6 +830,10 @@
           <source>Open properties in Multiple Windows</source>
           <target state="new">Open properties in Multiple Windows</target>
         </trans-unit>
+        <trans-unit id="ItemSizeBytes" translate="yes" xml:space="preserve">
+          <source>bytes</source>
+          <target state="new">bytes</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -833,6 +833,10 @@
           <source>Open properties in Multiple Windows</source>
           <target state="new">Open properties in Multiple Windows</target>
         </trans-unit>
+        <trans-unit id="ItemSizeBytes" translate="yes" xml:space="preserve">
+          <source>bytes</source>
+          <target state="new">bytes</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -833,6 +833,10 @@
           <source>Open properties in Multiple Windows</source>
           <target state="new">Open properties in Multiple Windows</target>
         </trans-unit>
+        <trans-unit id="ItemSizeBytes" translate="yes" xml:space="preserve">
+          <source>bytes</source>
+          <target state="new">bytes</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -835,6 +835,10 @@
           <source>Open properties in Multiple Windows</source>
           <target state="new">Open properties in Multiple Windows</target>
         </trans-unit>
+        <trans-unit id="ItemSizeBytes" translate="yes" xml:space="preserve">
+          <source>bytes</source>
+          <target state="translated">байт</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.ta.xlf
+++ b/Files/MultilingualResources/Files.ta.xlf
@@ -836,6 +836,10 @@
           <source>Open properties in Multiple Windows</source>
           <target state="new">Open properties in Multiple Windows</target>
         </trans-unit>
+        <trans-unit id="ItemSizeBytes" translate="yes" xml:space="preserve">
+          <source>bytes</source>
+          <target state="new">bytes</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -833,6 +833,10 @@
           <source>Open properties in Multiple Windows</source>
           <target state="new">Open properties in Multiple Windows</target>
         </trans-unit>
+        <trans-unit id="ItemSizeBytes" translate="yes" xml:space="preserve">
+          <source>bytes</source>
+          <target state="new">bytes</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -835,6 +835,10 @@
           <source>Open properties in Multiple Windows</source>
           <target state="new">Open properties in Multiple Windows</target>
         </trans-unit>
+        <trans-unit id="ItemSizeBytes" translate="yes" xml:space="preserve">
+          <source>bytes</source>
+          <target state="translated">байт</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -830,6 +830,10 @@
           <source>Open properties in Multiple Windows</source>
           <target state="new">Open properties in Multiple Windows</target>
         </trans-unit>
+        <trans-unit id="ItemSizeBytes" translate="yes" xml:space="preserve">
+          <source>bytes</source>
+          <target state="new">bytes</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -735,4 +735,7 @@
   <data name="BaseLayoutContextFlyoutPinDirectoryToSidebar.Text" xml:space="preserve">
     <value>Pin directory to sidebar</value>
   </data>
+  <data name="ItemSizeBytes" xml:space="preserve">
+    <value>bytes</value>
+  </data>
 </root>

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -1111,7 +1111,7 @@ namespace Files.Filesystem
                     fileSize = fDataFSize;
                 }
             }
-            var itemSize = ByteSize.FromBytes(fileSize).ToString();
+            var itemSize = ByteSize.FromBytes(fileSize).ToBinaryString();
             var itemSizeBytes = (findData.nFileSizeHigh << 32) + (ulong)findData.nFileSizeLow;
             string itemType = ResourceController.GetTranslation("ItemTypeFile");
             string itemFileExtension = null;
@@ -1197,7 +1197,7 @@ namespace Files.Filesystem
             var itemName = file.DisplayName;
             var itemDate = basicProperties.DateModified;
             var itemPath = file.Path;
-            var itemSize = ByteSize.FromBytes(basicProperties.Size).ToString();
+            var itemSize = ByteSize.FromBytes(basicProperties.Size).ToBinaryString();
             var itemSizeBytes = basicProperties.Size;
             var itemType = file.DisplayType;
             var itemFolderImgVis = false;

--- a/Files/View Models/SelectedItemsPropertiesViewModel.cs
+++ b/Files/View Models/SelectedItemsPropertiesViewModel.cs
@@ -214,7 +214,8 @@ namespace Files.View_Models
             {
                 var folderSize = await fileSizeTask;
                 ItemSizeReal = folderSize;
-                ItemsSize = ByteSizeLib.ByteSize.FromBytes(folderSize).ToString();
+                ItemsSize = ByteSizeLib.ByteSize.FromBytes(folderSize).ToBinaryString()
+                    + " (" + ByteSizeLib.ByteSize.FromBytes(folderSize).Bytes.ToString("#,##0") + " " + ResourceController.GetTranslation("ItemSizeBytes") + ")";
             }
             catch (Exception ex)
             {
@@ -286,7 +287,7 @@ namespace Files.View_Models
                         await Dispatcher.RunAsync(CoreDispatcherPriority.Low, () =>
                         {
                             ItemSizeReal = size;
-                            ItemsSize = ByteSizeLib.ByteSize.FromBytes(size).ToString();
+                            ItemsSize = ByteSizeLib.ByteSize.FromBytes(size).ToBinaryString();
                         });
                     }
 
@@ -310,7 +311,8 @@ namespace Files.View_Models
                 var file = await StorageFile.GetFileFromPathAsync(Item.ItemPath);
                 ItemCreatedTimestamp = ListedItem.GetFriendlyDate(file.DateCreated);
                 GetOtherPropeties(file.Properties);
-                ItemsSize = Item.FileSize;
+                ItemsSize = ByteSizeLib.ByteSize.FromBytes(Item.FileSizeBytes).ToBinaryString()
+                    + " (" + ByteSizeLib.ByteSize.FromBytes(Item.FileSizeBytes).Bytes.ToString("#,##0") + " " + ResourceController.GetTranslation("SizeBytes") + ")";
 
                 // Get file MD5 hash
                 var hashAlgTypeName = HashAlgorithmNames.Md5;


### PR DESCRIPTION
Fix incorrect drive space calculation
Show item size in bytes in properties window.
Before
![image](https://user-images.githubusercontent.com/20501502/85144665-253d6900-b254-11ea-838b-913b20f298f7.png)

After
![image](https://user-images.githubusercontent.com/20501502/85144677-29698680-b254-11ea-8b6c-c5a79e08f8a6.png)
