### PR TITLE
Gray out Empty recycle bin option in recycle bin page when it is empty

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -212,6 +212,8 @@ namespace Files
         public static PasteState PS { get; set; } = new PasteState();
         public static List<string> pathsToDeleteAfterPaste = new List<string>();
 
+        public static EmptyRecycleBinState ERBS { get; set; } = new EmptyRecycleBinState();
+
         /// <summary>
         /// Invoked when the application is launched normally by the end user.  Other entry points
         /// will be used such as when the application is launched to open a specific file.

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -565,5 +565,16 @@ namespace Files
                 e.Handled = true;
             }
         }
+        protected void Update_EmptyRecycleBin_State()
+        {
+            if (!AssociatedViewModel.IsLoadingItems && AssociatedViewModel.FilesAndFolders.Count <= 0)
+            {
+                App.ERBS.RecycleBinHasFiles = false;
+            }
+            else if (!AssociatedViewModel.IsLoadingItems)
+            {
+                App.ERBS.RecycleBinHasFiles = true;
+            }
+        }
     }
 }

--- a/Files/Interacts/ItemInteractions.cs
+++ b/Files/Interacts/ItemInteractions.cs
@@ -59,4 +59,33 @@ namespace Files.Interacts
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
+
+    public class EmptyRecycleBinState : INotifyPropertyChanged
+    {
+        private bool recycleBinHasFiles = true;
+
+        public bool RecycleBinHasFiles
+        {
+            get
+            {
+                return recycleBinHasFiles;
+            }
+
+            set
+            {
+                if (value != recycleBinHasFiles)
+                {
+                    recycleBinHasFiles = value;
+                    NotifyPropertyChanged("RecycleBinHasFiles");
+                }
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
 }

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -716,7 +716,7 @@
         </trans-unit>
         <trans-unit id="BaseLayoutContextFlyoutEmptyRecycleBin.Text" translate="yes" xml:space="preserve">
           <source>Empty recycle bin</source>
-          <target state="translated">空回收站</target>
+          <target state="translated">清空回收站</target>
         </trans-unit>
         <trans-unit id="BaseLayoutItemContextFlyoutRestore.Text" translate="yes" xml:space="preserve">
           <source>Restore</source>

--- a/Files/Strings/zh-Hans/Resources.resw
+++ b/Files/Strings/zh-Hans/Resources.resw
@@ -544,7 +544,7 @@
     <value>隐藏</value>
   </data>
   <data name="BaseLayoutContextFlyoutEmptyRecycleBin.Text" xml:space="preserve">
-    <value>空回收站</value>
+    <value>清空回收站</value>
   </data>
   <data name="BaseLayoutItemContextFlyoutRestore.Text" xml:space="preserve">
     <value>撤销</value>

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -204,7 +204,7 @@
                 x:Name="EmptyRecycleBin"
                 x:Uid="BaseLayoutContextFlyoutEmptyRecycleBin"
                 Click="{x:Bind local:App.CurrentInstance.InteractionOperations.EmptyRecycleBin_ClickAsync}"
-                IsEnabled="True"
+                IsEnabled="{x:Bind local:App.ERBS.RecycleBinHasFiles, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 Text="Empty recycle bin">
                 <MenuFlyoutItem.Icon>
                     <FontIcon FontFamily="{StaticResource RecycleBinIcons}" Glyph="&#xEF88;" />

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -218,8 +218,12 @@ namespace Files
             }
             else if (e.PropertyName == "IsLoadingItems")
             {
+                bool inRecycleBin = App.CurrentInstance.FilesystemViewModel.WorkingDirectory.StartsWith(AppSettings.RecycleBinPath);
                 if (!AssociatedViewModel.IsLoadingItems && AssociatedViewModel.FilesAndFolders.Count > 0)
                 {
+                    if (inRecycleBin)
+                        App.ERBS.RecycleBinHasFiles = true;
+
                     var allRows = new List<DataGridRow>();
 
                     Interacts.Interaction.FindChildren<DataGridRow>(allRows, AllView);
@@ -234,6 +238,10 @@ namespace Files
                             });
                         }
                     }
+                }
+                else if (!AssociatedViewModel.IsLoadingItems && inRecycleBin)
+                {
+                    App.ERBS.RecycleBinHasFiles = false;
                 }
             }
         }

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -218,12 +218,11 @@ namespace Files
             }
             else if (e.PropertyName == "IsLoadingItems")
             {
-                bool inRecycleBin = App.CurrentInstance.FilesystemViewModel.WorkingDirectory.StartsWith(AppSettings.RecycleBinPath);
+                if (App.CurrentInstance.FilesystemViewModel.WorkingDirectory.StartsWith(AppSettings.RecycleBinPath))
+                    base.Update_EmptyRecycleBin_State();
+
                 if (!AssociatedViewModel.IsLoadingItems && AssociatedViewModel.FilesAndFolders.Count > 0)
                 {
-                    if (inRecycleBin)
-                        App.ERBS.RecycleBinHasFiles = true;
-
                     var allRows = new List<DataGridRow>();
 
                     Interacts.Interaction.FindChildren<DataGridRow>(allRows, AllView);
@@ -238,10 +237,6 @@ namespace Files
                             });
                         }
                     }
-                }
-                else if (!AssociatedViewModel.IsLoadingItems && inRecycleBin)
-                {
-                    App.ERBS.RecycleBinHasFiles = false;
                 }
             }
         }

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -200,7 +200,7 @@
                 x:Name="EmptyRecycleBin"
                 x:Uid="BaseLayoutContextFlyoutEmptyRecycleBin"
                 Click="{x:Bind local:App.CurrentInstance.InteractionOperations.EmptyRecycleBin_ClickAsync}"
-                IsEnabled="True"
+                IsEnabled="{x:Bind local:App.ERBS.RecycleBinHasFiles, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 Text="Empty recycle bin">
                 <MenuFlyoutItem.Icon>
                     <FontIcon FontFamily="{StaticResource RecycleBinIcons}" Glyph="&#xEF88;" />


### PR DESCRIPTION
1. Attempt to fix issue: https://github.com/files-community/files-uwp/issues/1265
Note: the empty recycle bin option in fly out menu of navigation bar remains unchanged.

2. Correct a Chinese translation.