### PR TITLE
Fix dialog-related issues

### DIFF
--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -276,13 +276,6 @@ namespace FilesFullTrust
                         var binSize = queryBinInfo.i64Size;
                         responseQuery.Add("NumItems", numItems);
                         responseQuery.Add("BinSize", binSize);
-                        responseQuery.Add("FileOwner", (string)recycler.Properties[Vanara.PInvoke.Ole32.PROPERTYKEY.System.FileOwner]);
-                        if (watchers.Any())
-                        {
-                            var info = new DirectoryInfo(watchers.First().Path);
-                            responseQuery.Add("DateAccessed", info.LastAccessTime.ToBinary());
-                            responseQuery.Add("DateCreated", info.CreationTime.ToBinary());
-                        }
                         await args.Request.SendResponseAsync(responseQuery);
                     }
                     break;

--- a/Files/Dialogs/ConfirmDeleteDialog.xaml
+++ b/Files/Dialogs/ConfirmDeleteDialog.xaml
@@ -31,7 +31,7 @@
                 x:Name="chkPermanentlyDelete"
                 x:Uid="ConfirmDeleteDialogPermanentlyDeleteCheckBox"
                 Content="Permanently delete"
-                IsChecked="{x:Bind local1:App.InteractionViewModel.PermanentlyDelete, Mode=TwoWay, Converter={StaticResource StorageDeleteOptionToBooleanConverter}}" />
+                IsChecked="{x:Bind PermanentlyDelete, Mode=TwoWay, Converter={StaticResource StorageDeleteOptionToBooleanConverter}}" />
         </StackPanel>
 
         <StackPanel

--- a/Files/Dialogs/ConfirmDeleteDialog.xaml.cs
+++ b/Files/Dialogs/ConfirmDeleteDialog.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Windows.UI.Xaml;
+﻿using Windows.Storage;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 // The Content Dialog item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
@@ -7,6 +8,7 @@ namespace Files.Dialogs
 {
     public sealed partial class ConfirmDeleteDialog : ContentDialog
     {
+        public StorageDeleteOption PermanentlyDelete { get; set; }
         public MyResult Result { get; set; }
 
         public enum MyResult
@@ -16,11 +18,12 @@ namespace Files.Dialogs
             Nothing
         }
 
-        public ConfirmDeleteDialog(bool deleteFromRecycleBin = false)
+        public ConfirmDeleteDialog(bool deleteFromRecycleBin, StorageDeleteOption deleteOption)
         {
             this.InitializeComponent();
 
             this.Result = MyResult.Nothing; //clear the result in case the value is set from last time
+            this.PermanentlyDelete = deleteOption;
 
             // If deleting from recycle bin disable "permanently delete" option
             this.chkPermanentlyDelete.IsEnabled = !deleteFromRecycleBin;

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -593,25 +593,30 @@ namespace Files.Interacts
             dataRequestDeferral.Complete();
         }
 
-        public async void DeleteItem_Click(object sender, RoutedEventArgs e)
+        public void DeleteItem_Click(object sender, RoutedEventArgs e)
+        {
+            DeleteItem(StorageDeleteOption.Default);
+        }
+
+        public async void DeleteItem(StorageDeleteOption deleteOption)
         {
             var deleteFromRecycleBin = CurrentInstance.FilesystemViewModel.WorkingDirectory.StartsWith(AppSettings.RecycleBinPath);
             if (deleteFromRecycleBin)
             {
                 // Permanently delete if deleting from recycle bin
-                App.InteractionViewModel.PermanentlyDelete = StorageDeleteOption.PermanentDelete;
+                deleteOption = StorageDeleteOption.PermanentDelete;
             }
 
             if (AppSettings.ShowConfirmDeleteDialog == true) //check if the setting to show a confirmation dialog is on
             {
-                var dialog = new ConfirmDeleteDialog(deleteFromRecycleBin);
+                var dialog = new ConfirmDeleteDialog(deleteFromRecycleBin, deleteOption);
                 await dialog.ShowAsync();
 
                 if (dialog.Result != MyResult.Delete) //delete selected  item(s) if the result is yes
                 {
-                    App.InteractionViewModel.PermanentlyDelete = StorageDeleteOption.Default; //reset PermanentlyDelete flag
                     return; //return if the result isn't delete
                 }
+                deleteOption = dialog.PermanentlyDelete;
             }
             StatusBanner banner = null;
             try
@@ -654,7 +659,7 @@ namespace Files.Interacts
                                 item = await ItemViewModel.GetFolderFromPathAsync(storItem.ItemPath);
                             }
 
-                            await item.DeleteAsync(App.InteractionViewModel.PermanentlyDelete);
+                            await item.DeleteAsync(deleteOption);
                         }
                         catch (FileLoadException)
                         {
@@ -668,7 +673,7 @@ namespace Files.Interacts
                                 item = await ItemViewModel.GetFolderFromPathAsync(storItem.ItemPath);
                             }
 
-                            await item.DeleteAsync(App.InteractionViewModel.PermanentlyDelete);
+                            await item.DeleteAsync(deleteOption);
                         }
 
                         if (deleteFromRecycleBin)
@@ -701,11 +706,10 @@ namespace Files.Interacts
                     ResourceController.GetTranslation("FileInUseDeleteDialog/PrimaryButtonText"),
                     ResourceController.GetTranslation("FileInUseDeleteDialog/SecondaryButtonText")))
                 {
-                    DeleteItem_Click(null, null);
+                    DeleteItem(deleteOption);
                 }
             }
             App.CurrentInstance.StatusBarControl.OngoingTasksControl.RemoveBanner(banner);
-            App.InteractionViewModel.PermanentlyDelete = StorageDeleteOption.Default; //reset PermanentlyDelete flag
         }
 
         public void RenameItem_Click(object sender, RoutedEventArgs e)

--- a/Files/View Models/InteractionViewModel.cs
+++ b/Files/View Models/InteractionViewModel.cs
@@ -31,14 +31,6 @@ namespace Files.Controls
             set => Set(ref _LeftMarginLoaded, value);
         }
 
-        private StorageDeleteOption _PermanentlyDelete = StorageDeleteOption.Default;
-
-        public StorageDeleteOption PermanentlyDelete
-        {
-            get => _PermanentlyDelete;
-            set => Set(ref _PermanentlyDelete, value);
-        }
-
         private bool _IsSelectedItemImage = false;
 
         public bool IsSelectedItemImage

--- a/Files/View Models/Properties/FolderProperties.cs
+++ b/Files/View Models/Properties/FolderProperties.cs
@@ -66,14 +66,31 @@ namespace Files.View_Models.Properties
                         var response = await App.Connection.SendMessageAsync(value);
                         if (response.Status == Windows.ApplicationModel.AppService.AppServiceResponseStatus.Success)
                         {
-                            ViewModel.ItemCreatedTimestamp = ListedItem.GetFriendlyDate(DateTime.FromBinary((long)response.Message["DateCreated"]));
-                            ViewModel.ItemSizeBytes = (long)response.Message["BinSize"];
-                            ViewModel.ItemSize = ByteSize.FromBytes((long)response.Message["BinSize"]).ToString();
-                            ViewModel.FilesCount = (int)(long)response.Message["NumItems"];
-                            SetItemsCountString();
-                            ViewModel.ItemAccessedTimestamp = ListedItem.GetFriendlyDate(DateTime.FromBinary((long)response.Message["DateAccessed"]));
+                            if (response.Message.TryGetValue("BinSize", out var binSize))
+                            {
+                                ViewModel.ItemSizeBytes = (long)binSize;
+                                ViewModel.ItemSize = ByteSize.FromBytes((long)binSize).ToString();
+                                ViewModel.ItemSizeVisibility = Visibility.Visible;
+                            }
+                            else
+                            {
+                                ViewModel.ItemSizeVisibility = Visibility.Collapsed;
+                            }
+                            if (response.Message.TryGetValue("NumItems", out var numItems))
+                            {
+                                ViewModel.FilesCount = (int)(long)numItems;
+                                SetItemsCountString();
+                                ViewModel.FilesAndFoldersCountVisibility = Visibility.Visible;
+                            }
+                            else
+                            {
+                                ViewModel.FilesAndFoldersCountVisibility = Visibility.Collapsed;
+                            }
+                            ViewModel.ItemCreatedTimestampVisibiity = Visibility.Collapsed;
+                            ViewModel.ItemAccessedTimestampVisibility = Visibility.Collapsed;
+                            ViewModel.ItemModifiedTimestampVisibility = Visibility.Collapsed;
                             ViewModel.ItemFileOwnerVisibility = Visibility.Collapsed;
-                            ViewModel.ItemSizeVisibility = Visibility.Visible;
+                            ViewModel.LastSeparatorVisibility = Visibility.Collapsed;
                         }
                     }
                 }

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -398,7 +398,8 @@ namespace Files
                 if (App.CurrentInstance.CurrentPageType == typeof(GenericFileBrowser))
                 {
                     var focusedElement = FocusManager.GetFocusedElement(XamlRoot) as FrameworkElement;
-                    if (focusedElement is TextBox || focusedElement is PasswordBox)
+                    if (focusedElement is TextBox || focusedElement is PasswordBox ||
+                        Interacts.Interaction.FindParent<ContentDialog>(focusedElement) != null)
                     {
                         return;
                     }

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -311,7 +311,8 @@ namespace Files
                 if (App.CurrentInstance.CurrentPageType == typeof(GridViewBrowser) && !isRenamingItem)
                 {
                     var focusedElement = FocusManager.GetFocusedElement(XamlRoot) as FrameworkElement;
-                    if (focusedElement is TextBox || focusedElement is PasswordBox)
+                    if (focusedElement is TextBox || focusedElement is PasswordBox ||
+                        Interacts.Interaction.FindParent<ContentDialog>(focusedElement) != null)
                     {
                         return;
                     }

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -291,6 +291,17 @@ namespace Files
             {
                 AssociatedInteractions.ShowPropertiesButton_Click(null, null);
             }
+            else if (e.Key == VirtualKey.Space)
+            {
+                if (!isRenamingItem && !App.CurrentInstance.NavigationToolbar.IsEditModeEnabled)
+                {
+                    if ((App.CurrentInstance.ContentPage).IsQuickLookEnabled)
+                    {
+                        App.CurrentInstance.InteractionOperations.ToggleQuickLook();
+                    }
+                    e.Handled = true;
+                }
+            }
         }
 
         protected override void Page_CharacterReceived(CoreWindow sender, CharacterReceivedEventArgs args)

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -210,8 +210,7 @@ namespace Files.Views.Pages
 
                 case (false, true, false, true, VirtualKey.Delete): // shift + delete, PermanentDelete
                     if (!App.CurrentInstance.NavigationToolbar.IsEditModeEnabled)
-                        App.InteractionViewModel.PermanentlyDelete = StorageDeleteOption.PermanentDelete;
-                    App.CurrentInstance.InteractionOperations.DeleteItem_Click(null, null);
+                        App.CurrentInstance.InteractionOperations.DeleteItem(StorageDeleteOption.PermanentDelete);
                     break;
 
                 case (true, false, false, true, VirtualKey.C): // ctrl + c, copy
@@ -260,7 +259,7 @@ namespace Files.Views.Pages
 
                 case (false, false, false, true, VirtualKey.Delete): // delete, delete item
                     if (App.CurrentInstance.ContentPage.IsItemSelected && !App.CurrentInstance.ContentPage.isRenamingItem)
-                        App.CurrentInstance.InteractionOperations.DeleteItem_Click(null, null);
+                        App.CurrentInstance.InteractionOperations.DeleteItem(StorageDeleteOption.Default);
                     break;
 
                 case (false, false, false, true, VirtualKey.Space): // space, quick look


### PR DESCRIPTION
This PR fixes a few issues related to dialogs.
In particular:
- Pressing 'Space' to activate QuickLook only works in List View #1322
-> GridView seems to "swallow" the Space key, for `GridViewBrowser` the Space key is now handled in `FileList_PreviewKeyDown`

- Properties window not working for recycle bin #1263
-> Properties dialog for recycle bin was removed in #1264, this removes the code causing the exception in #1263

- Pressing space key while focused on the "permanently delete" checkbox in the "delete item(s)" modal dialog breaks keyboard navigation #1323
-> When a key is pressed the file list is focused only if no dialog is currently displayed

- After canceling a permanent deletion, if you press "shift + del" again in the same file, "permanently delete" is no longer checked again #1253
-> Fix a bug with "{x:Bind}" that was causing multiple `ConfirmDeleteDialog` to persist after being closed
-> Fix the "permanently delete" option not being checked if the dialog was canceled and reopened quickly

Let me know if you wish this split into separate PRs for each item (each commit in this fixes a single issue)