### PR TITLE
Properties: Fix missing font family for drives icon

### DIFF
--- a/Files/Views/Pages/Properties.xaml
+++ b/Files/Views/Pages/Properties.xaml
@@ -111,6 +111,7 @@
                         HorizontalAlignment="Center"
                         VerticalAlignment="Stretch"
                         x:Load="{x:Bind ViewModel.LoadDriveItemGlyph, Mode=OneWay}"
+                        FontFamily="{StaticResource FluentUIGlyphs}"
                         FontSize="70"
                         Glyph="{x:Bind ViewModel.DriveItemGlyphSource, Mode=OneWay}" />
                     <Image


### PR DESCRIPTION
Fixes #1405 
--------------------
**Before:**
Local drive: ![Anotación 2020-07-12 174404](https://user-images.githubusercontent.com/61259627/87257683-ed000380-c46a-11ea-8359-e2893f363dc6.png)

Network drive: ![Anotación 2020-07-12 174418](https://user-images.githubusercontent.com/61259627/87257684-ed989a00-c46a-11ea-9f04-0c1c22b72843.png)

--------------------------------

**After:**
Local drive: ![Anotación 2020-07-12 181109](https://user-images.githubusercontent.com/61259627/87257698-1c167500-c46b-11ea-9e32-4dc9a7e40f7f.png)

Network drive: ![Anotación 2020-07-12 181121](https://user-images.githubusercontent.com/61259627/87257699-1caf0b80-c46b-11ea-910d-9c6e76c2d6a8.png)


