### PR TITLE
Bump Vanara.Windows.Shell from 3.2.11 to 3.2.12

### DIFF
--- a/Files.Launcher/Files.Launcher.csproj
+++ b/Files.Launcher/Files.Launcher.csproj
@@ -133,7 +133,7 @@
       <Version>4.7.0</Version>
     </PackageReference>
     <PackageReference Include="Vanara.Windows.Shell">
-      <Version>3.2.11</Version>
+      <Version>3.2.12</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -422,7 +422,7 @@ namespace FilesFullTrust
                                         menu = sf.GetChildrenUIObjects<Shell32.IContextMenu>(null, files.ToArray());
                                         menu.QueryContextMenu(HMENU.NULL, 0, 0, 0, Shell32.CMF.CMF_DEFAULTONLY);
                                         var pici = new Shell32.CMINVOKECOMMANDINFOEX();
-                                        pici.lpVerb = Shell32.CMDSTR_OPEN;
+                                        pici.lpVerb = new SafeResourceId(Shell32.CMDSTR_OPEN, CharSet.Ansi);
                                         pici.nShow = ShowWindowCommand.SW_SHOW;
                                         pici.cbSize = (uint)Marshal.SizeOf(pici);
                                         menu.InvokeCommand(pici);


### PR DESCRIPTION
Fixes compile error when updating library.
This update is useful for context-menu implementation