### PR TITLE
Cancel Action Without Error Message When Drag One Or More Folders and Drop on itself (themselves) 

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -508,9 +508,27 @@ namespace Files
 
         protected async void Item_Drop(object sender, DragEventArgs e)
         {
+            IReadOnlyList<IStorageItem> draggedItemsList = await e.DataView.GetStorageItemsAsync();
             e.Handled = true;
             ListedItem rowItem = GetItemFromElement(sender);
-            await App.CurrentInstance.InteractionOperations.PasteItems(e.DataView, rowItem.ItemPath, e.AcceptedOperation);
+            bool droppedOnDraggedItem = false;
+            foreach(IStorageItem draggedItem in draggedItemsList)
+            {
+                if (rowItem.ItemPath == draggedItem.Path)
+                {
+                    droppedOnDraggedItem = true;
+                    break;
+                }
+                    
+            }
+            if (!droppedOnDraggedItem)
+            {
+                await App.CurrentInstance.InteractionOperations.PasteItems(e.DataView, rowItem.ItemPath, e.AcceptedOperation);
+            }
+            else
+            {
+                e.DataView.ReportOperationCompleted(e.AcceptedOperation);
+            }
         }
 
         protected void InitializeDrag(UIElement element)

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -519,7 +519,6 @@ namespace Files
                     droppedOnDraggedItem = true;
                     break;
                 }
-                    
             }
 
             if (!droppedOnDraggedItem)

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -492,10 +492,14 @@ namespace Files
 
             if (e.DataView.Contains(StandardDataFormats.StorageItems))
             {
-                e.Handled = true;
                 IReadOnlyList<IStorageItem> draggedItems = await e.DataView.GetStorageItemsAsync();
+                e.Handled = true;
                 // Items from the same parent folder as this folder are dragged into this folder, so we move the items instead of copy
-                if (draggedItems.Any(draggedItem => Directory.GetParent(draggedItem.Path).FullName == Directory.GetParent(item.ItemPath).FullName))
+                if (draggedItems.Any(draggedItem => draggedItem.Path == item.ItemPath))
+                {
+                    e.AcceptedOperation = DataPackageOperation.None;
+                }
+                else if (draggedItems.Any(draggedItem => Directory.GetParent(draggedItem.Path).FullName == Directory.GetParent(item.ItemPath).FullName))
                 {
                     e.AcceptedOperation = DataPackageOperation.Move;
                 }
@@ -511,17 +515,8 @@ namespace Files
             IReadOnlyList<IStorageItem> draggedItemsList = await e.DataView.GetStorageItemsAsync();
             e.Handled = true;
             ListedItem rowItem = GetItemFromElement(sender);
-            bool droppedOnDraggedItem = false;
-            foreach(IStorageItem draggedItem in draggedItemsList)
-            {
-                if (rowItem.ItemPath == draggedItem.Path)
-                {
-                    droppedOnDraggedItem = true;
-                    break;
-                }
-            }
 
-            if (!droppedOnDraggedItem)
+            if (draggedItemsList.Any(draggedItem => draggedItem.Path == rowItem.ItemPath))
             {
                 await App.CurrentInstance.InteractionOperations.PasteItems(e.DataView, rowItem.ItemPath, e.AcceptedOperation);
             }

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -512,18 +512,9 @@ namespace Files
 
         protected async void Item_Drop(object sender, DragEventArgs e)
         {
-            IReadOnlyList<IStorageItem> draggedItemsList = await e.DataView.GetStorageItemsAsync();
             e.Handled = true;
             ListedItem rowItem = GetItemFromElement(sender);
-
-            if (draggedItemsList.Any(draggedItem => draggedItem.Path == rowItem.ItemPath))
-            {
-                await App.CurrentInstance.InteractionOperations.PasteItems(e.DataView, rowItem.ItemPath, e.AcceptedOperation);
-            }
-            else
-            {
-                e.DataView.ReportOperationCompleted(e.AcceptedOperation);
-            }
+            await App.CurrentInstance.InteractionOperations.PasteItems(e.DataView, rowItem.ItemPath, e.AcceptedOperation);
         }
 
         protected void InitializeDrag(UIElement element)

--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -521,6 +521,7 @@ namespace Files
                 }
                     
             }
+
             if (!droppedOnDraggedItem)
             {
                 await App.CurrentInstance.InteractionOperations.PasteItems(e.DataView, rowItem.ItemPath, e.AcceptedOperation);


### PR DESCRIPTION
Attempted to fix issue #1379.
Make it do nothing when drag a folder and drop it on itself and when drag some files and folders and drop them on one of the dragged folder. 