### PR TITLE
Fix for random error when saving to jumplist

### DIFF
--- a/Files/Helpers/JumpListManager.cs
+++ b/Files/Helpers/JumpListManager.cs
@@ -33,8 +33,14 @@ namespace Files.Helpers
 
         public async void AddFolderToJumpList(string path)
         {
-            await AddFolder(path);
-            await _instance?.SaveAsync();
+            // Saving to jumplist may fail randomly with error: ERROR_UNABLE_TO_REMOVE_REPLACED
+            // In that case app should just catch the error and proceed as usual
+            try
+            {
+                await AddFolder(path);
+                await _instance?.SaveAsync();
+            }
+            catch { }
         }
 
         private Task AddFolder(string path)


### PR DESCRIPTION
Saving to jumplist may fail randomly with error: ERROR_UNABLE_TO_REMOVE_REPLACED. In that case app should just catch the error and proceed as usual.