### PR TITLE
[Need Help] Fixing some problems in tab navigation

### DIFF
--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -127,14 +127,14 @@ namespace Files.Interacts
             {
                 await CoreWindow.GetForCurrentThread().Dispatcher.RunAsync(CoreDispatcherPriority.Low, async () =>
                 {
-                    await MainPage.AddNewTab(typeof(ModernShellPage), listedItem.ItemPath);
+                    await MainPage.AddNewTab(typeof(ModernShellPage), listedItem.ItemPath, -1, false);
                 });
             }
         }
 
         public async void OpenPathInNewTab(string path)
         {
-            await MainPage.AddNewTab(typeof(ModernShellPage), path);
+            await MainPage.AddNewTab(typeof(ModernShellPage), path, -1, false);
         }
 
         public static async Task<bool> OpenPathInNewWindow(string path)
@@ -444,7 +444,7 @@ namespace Files.Interacts
                 {
                     foreach (ListedItem clickedOnItem in CurrentInstance.ContentPage.SelectedItems.Where(x => x.PrimaryItemAttribute == StorageItemTypes.Folder))
                     {
-                        await MainPage.AddNewTab(typeof(ModernShellPage), clickedOnItem.ItemPath);
+                        await MainPage.AddNewTab(typeof(ModernShellPage), clickedOnItem.ItemPath, -1, false);
                     }
                     foreach (ListedItem clickedOnItem in CurrentInstance.ContentPage.SelectedItems.Where(x => x.PrimaryItemAttribute == StorageItemTypes.File))
                     {

--- a/Files/UserControls/ModernNavigationToolbar.xaml.cs
+++ b/Files/UserControls/ModernNavigationToolbar.xaml.cs
@@ -32,12 +32,18 @@ namespace Files.UserControls
         {
             this.InitializeComponent();
 
-            MainPage.OnTabItemDraggedOver += MainPage_OnTabItemDraggedOver;
+            MainPage.TabFlyoutOpenIndicator += OnTabFlyoutOpenIndicated;
         }
 
-        private void MainPage_OnTabItemDraggedOver(object sender, bool e)
+        private async void OnTabFlyoutOpenIndicated(object sender, EventArgs e)
         {
-            VerticalTabViewFlyout.ShowAt(VerticalTabStripInvokeButton);
+            if (!(bool)VerticalTabStripInvokeButton?.Flyout?.IsOpen)
+            {
+                await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.High, () =>
+                {
+                    VerticalTabStripInvokeButton?.Flyout?.ShowAt(VerticalTabStripInvokeButton);
+                });
+            }
         }
 
         private bool manualEntryBoxLoaded = false;

--- a/Files/UserControls/VerticalTabView.xaml.cs
+++ b/Files/UserControls/VerticalTabView.xaml.cs
@@ -299,7 +299,7 @@ namespace Files.UserControls
             }
 
             ApplicationData.Current.LocalSettings.Values[TabDropHandledIdentifier] = true;
-            await MainPage.AddNewTab(typeof(ModernShellPage), tabViewItemPath, index);
+            await MainPage.AddNewTab(typeof(ModernShellPage), tabViewItemPath, index, true);
         }
 
         private void TabStrip_TabDragCompleted(TabView sender, TabViewTabDragCompletedEventArgs args)

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -54,7 +54,7 @@ namespace Files.Views
         public static ObservableCollection<TabItem> AppInstances = new ObservableCollection<TabItem>();
         public static ObservableCollection<INavigationControlItem> sideBarItems = new ObservableCollection<INavigationControlItem>();
 
-        public static event EventHandler<bool> OnTabItemDraggedOver;
+        public static event EventHandler TabFlyoutOpenIndicator;
 
         public MainPage()
         {
@@ -78,7 +78,7 @@ namespace Files.Views
         {
             if (e.DataView.Properties.ContainsKey(VerticalTabView.TabPathIdentifier))
             {
-                OnTabItemDraggedOver?.Invoke(sender, true);
+                TabFlyoutOpenIndicator?.Invoke(null, null);
             }
         }
 
@@ -132,7 +132,7 @@ namespace Files.Views
             }
         }
 
-        public static async Task AddNewTab(Type t, string path, int atIndex = -1)
+        public static async Task AddNewTab(Type t, string path, int atIndex = -1, bool? switchToNewTab = null)
         {
             string tabLocationHeader = null;
             Microsoft.UI.Xaml.Controls.FontIconSource fontIconSource = new Microsoft.UI.Xaml.Controls.FontIconSource();
@@ -265,6 +265,15 @@ namespace Files.Views
             MainPage.AppInstances.Insert(atIndex == -1 ? AppInstances.Count : atIndex, tvi);
             var tabViewItemFrame = (tvi.Content as Grid).Children[0] as Frame;
             tabViewItemFrame.Loaded += TabViewItemFrame_Loaded;
+
+            if (switchToNewTab == true)
+            {
+                App.InteractionViewModel.TabStripSelectedIndex = MainPage.AppInstances.IndexOf(tvi);
+            }
+            else if (switchToNewTab == false)
+            {
+                TabFlyoutOpenIndicator?.Invoke(null, null);
+            }
         }
 
         private static void TabViewItemFrame_Loaded(object sender, RoutedEventArgs e)
@@ -392,7 +401,7 @@ namespace Files.Views
 
         private async void AddNewInstanceAccelerator_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
         {
-            await AddNewTab(typeof(ModernShellPage), ResourceController.GetTranslation("NewTab"));
+            await AddNewTab(typeof(ModernShellPage), ResourceController.GetTranslation("NewTab"), -1, true);
             args.Handled = true;
         }
     }


### PR DESCRIPTION
Attempts to fix #1537. The new behavior looks like this:
1. Creating tab with keyboard shortcut switches to that tab.
2. Creating tab from the Tabview flyout doesn't switch to the tab.
3. Creating tabs by right clicking on folders and sidebar items expands the TabView flyout to indicate you tabs are created.