### PR TITLE
Fixed a bug where invert selection didn't work

### DIFF
--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -109,7 +109,7 @@ namespace Files
             ClearSelection();
             foreach (ListedItem selectedItem in selectedItems)
             {
-                AllView.SelectedItem = selectedItem;
+                AllView.SelectedItems.Add(selectedItem);
             }
         }
 


### PR DESCRIPTION
This PR fixes #1542 

The error occurred when setting the SelectedItems. Instead of adding all items to the SelectedItems Property, only the SelectedItem property was updated

