### PR TITLE
Improve path components calculation

### DIFF
--- a/Files/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
+++ b/Files/Filesystem/StorageFileHelpers/StorageFileExtensions.cs
@@ -18,81 +18,67 @@ namespace Files.Filesystem
     {
         private static SettingsViewModel _AppSettings => App.AppSettings;
 
-        public static List<PathBoxItem> GetDirectoryPathComponents(string value)
+        private static PathBoxItem GetPathItem(string component, string path)
         {
-            List<string> pathComponents = new List<string>();
-            List<PathBoxItem> pathBoxItems = new List<PathBoxItem>();
-
-            // If path is a library, simplify it
-            // If path is found to not be a library
-            if (value.StartsWith("\\\\?\\"))
+            if (component.StartsWith(App.AppSettings.RecycleBinPath))
             {
-                pathComponents = value.Replace("\\\\?\\", "").Split("\\", StringSplitOptions.RemoveEmptyEntries).ToList();
+                // Handle the recycle bin: use the localized folder name
+                return new PathBoxItem()
+                {
+                    Title = ApplicationData.Current.LocalSettings.Values.Get("RecycleBin_Title", "Recycle Bin"),
+                    Path = path,
+                };
+            }
+            else if (component.Contains(":"))
+            {
+                return new PathBoxItem()
+                {
+                    Title = MainPage.sideBarItems
+                        .FirstOrDefault(x => x.ItemType == NavigationControlItemType.Drive &&
+                            x.Path.Contains(component, StringComparison.OrdinalIgnoreCase)) != null ?
+                            MainPage.sideBarItems
+                                .FirstOrDefault(x => x.ItemType == NavigationControlItemType.Drive &&
+                                    x.Path.Contains(component, StringComparison.OrdinalIgnoreCase)).Text :
+                            @"Drive (" + component + @"\)",
+                    Path = path,
+                };
             }
             else
             {
-                pathComponents = value.Split("\\", StringSplitOptions.RemoveEmptyEntries).ToList();
+                return new PathBoxItem
+                {
+                    Title = component,
+                    Path = path
+                };
             }
+        }
 
-            int index = 0;
-            foreach (string s in pathComponents)
+        public static List<PathBoxItem> GetDirectoryPathComponents(string value)
+        {
+            List<PathBoxItem> pathBoxItems = new List<PathBoxItem>();
+
+            if (!value.EndsWith("\\")) value += "\\";
+
+            int lastIndex = 0;
+
+            for (var i = 0; i < value.Length; i++)
             {
-                string componentLabel = null;
-                string tag = "";
-                if (s.StartsWith(App.AppSettings.RecycleBinPath))
+                if (value[i] == '\\' || value[i] == '?')
                 {
-                    // Handle the recycle bin: use the localized folder name
-                    PathBoxItem item = new PathBoxItem()
+                    if (lastIndex == i)
                     {
-                        Title = ApplicationData.Current.LocalSettings.Values.Get("RecycleBin_Title", "Recycle Bin"),
-                        Path = tag,
-                    };
-                    App.CurrentInstance.NavigationToolbar.PathComponents.Add(item);
-                }
-                else if (s.Contains(":"))
-                {
-                    if (MainPage.sideBarItems.FirstOrDefault(x => x.ItemType == NavigationControlItemType.Drive && x.Path.Contains(s, StringComparison.OrdinalIgnoreCase)) != null)
-                    {
-                        componentLabel = MainPage.sideBarItems.FirstOrDefault(x => x.ItemType == NavigationControlItemType.Drive && x.Path.Contains(s, StringComparison.OrdinalIgnoreCase)).Text;
-                    }
-                    else
-                    {
-                        componentLabel = @"Drive (" + s + @"\)";
-                    }
-                    tag = s + @"\";
-
-                    PathBoxItem item = new PathBoxItem()
-                    {
-                        Title = componentLabel,
-                        Path = tag,
-                    };
-                    pathBoxItems.Add(item);
-                }
-                else
-                {
-                    componentLabel = s;
-                    foreach (string part in pathComponents.GetRange(0, index + 1))
-                    {
-                        tag = tag + part + @"\";
-                    }
-                    if (value.StartsWith("\\\\?\\"))
-                    {
-                        tag = "\\\\?\\" + tag;
-                    }
-                    else if (index == 0)
-                    {
-                        tag = "\\\\" + tag;
+                        lastIndex = i + 1;
+                        continue;
                     }
 
-                    PathBoxItem item = new PathBoxItem()
-                    {
-                        Title = componentLabel,
-                        Path = tag,
-                    };
-                    pathBoxItems.Add(item);
+                    var component = value.Substring(lastIndex, i - lastIndex);
+                    var path = value.Substring(0, i + 1);
+                    pathBoxItems.Add(GetPathItem(component, path));
+
+                    lastIndex = i + 1;
                 }
-                index++;
             }
+
             return pathBoxItems;
         }
 


### PR DESCRIPTION
Re-implement path components calculation with a clearer logic.

- Fix bugs in handling network path, eg. `\\192.168.1.1\test`, `\\wsl$\Ubuntu\home`, existing implementation lost the prefixed `\\` in the path
- Make the logic clearer for maintainability 
