### PR TITLE
Fixed incorrect file deletion bug

### DIFF
--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -683,11 +683,19 @@ namespace Files.Interacts
 
         public async void DeleteItem(StorageDeleteOption deleteOption)
         {
-            var deleteFromRecycleBin = CurrentInstance.FilesystemViewModel.WorkingDirectory.StartsWith(AppSettings.RecycleBinPath);
+            var deleteFromRecycleBin = App.CurrentInstance.FilesystemViewModel.WorkingDirectory.StartsWith(AppSettings.RecycleBinPath);
             if (deleteFromRecycleBin)
             {
                 // Permanently delete if deleting from recycle bin
                 deleteOption = StorageDeleteOption.PermanentDelete;
+            }
+
+            // Get selected items before showing the prompt to prevent deleting items selected after the prompt
+            var CurrentInstance = App.CurrentInstance;
+            List<ListedItem> selectedItems = new List<ListedItem>();
+            foreach (ListedItem selectedItem in CurrentInstance.ContentPage.SelectedItems)
+            {
+                selectedItems.Add(selectedItem);
             }
 
             if (AppSettings.ShowConfirmDeleteDialog == true) //check if the setting to show a confirmation dialog is on
@@ -704,12 +712,6 @@ namespace Files.Interacts
             StatusBanner banner = null;
             try
             {
-                var CurrentInstance = App.CurrentInstance;
-                List<ListedItem> selectedItems = new List<ListedItem>();
-                foreach (ListedItem selectedItem in CurrentInstance.ContentPage.SelectedItems)
-                {
-                    selectedItems.Add(selectedItem);
-                }
                 int itemsDeleted = 0;
                 if (selectedItems.Count > 3)
                 {


### PR DESCRIPTION
Possible fix for #1636 
![ezgif-4-5c0a55019b75](https://user-images.githubusercontent.com/46000533/89185658-e14fba80-d59a-11ea-8d67-6909f9ca857a.gif)

Only difference is the selected items are retrieved before the deletion prompt is shown, hence any changes to the selection after the prompt is confirmed have no effect on the items listed for deletion.