### PR TITLE
Replaced string property names with nameof()

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -52,7 +52,7 @@ namespace Files
                 if (value != isItemSelected)
                 {
                     isItemSelected = value;
-                    NotifyPropertyChanged("IsItemSelected");
+                    NotifyPropertyChanged(nameof(IsItemSelected));
                 }
             }
         }
@@ -106,7 +106,7 @@ namespace Files
                             }
                         }
                     }
-                    NotifyPropertyChanged("SelectedItems");
+                    NotifyPropertyChanged(nameof(SelectedItems));
                     SetDragModeForItems();
                 }
             }

--- a/Files/Helpers/AcrylicTheme.cs
+++ b/Files/Helpers/AcrylicTheme.cs
@@ -17,7 +17,7 @@ namespace Files.Helpers
             set
             {
                 _FallbackColor = value;
-                NotifyPropertyChanged("FallbackColor");
+                NotifyPropertyChanged(nameof(FallbackColor));
             }
         }
 
@@ -27,7 +27,7 @@ namespace Files.Helpers
             set
             {
                 _TintColor = value;
-                NotifyPropertyChanged("TintColor");
+                NotifyPropertyChanged(nameof(TintColor));
             }
         }
 
@@ -37,7 +37,7 @@ namespace Files.Helpers
             set
             {
                 _TintOpacity = value;
-                NotifyPropertyChanged("TintOpacity");
+                NotifyPropertyChanged(nameof(TintOpacity));
             }
         }
 

--- a/Files/UserControls/ModernNavigationToolbar.xaml.cs
+++ b/Files/UserControls/ModernNavigationToolbar.xaml.cs
@@ -47,7 +47,7 @@ namespace Files.UserControls
                 if (value != manualEntryBoxLoaded)
                 {
                     manualEntryBoxLoaded = value;
-                    NotifyPropertyChanged("ManualEntryBoxLoaded");
+                    NotifyPropertyChanged(nameof(ManualEntryBoxLoaded));
                 }
             }
         }
@@ -65,7 +65,7 @@ namespace Files.UserControls
                 if (value != clickablePathLoaded)
                 {
                     clickablePathLoaded = value;
-                    NotifyPropertyChanged("ClickablePathLoaded");
+                    NotifyPropertyChanged(nameof(ClickablePathLoaded));
                 }
             }
         }
@@ -188,7 +188,7 @@ namespace Files.UserControls
             set
             {
                 PathText = value;
-                NotifyPropertyChanged("PathText");
+                NotifyPropertyChanged(nameof(PathText));
             }
         }
 

--- a/Files/UserControls/SidebarControl.xaml.cs
+++ b/Files/UserControls/SidebarControl.xaml.cs
@@ -36,7 +36,7 @@ namespace Files.Controls
                 if (value != _SelectedSidebarItem)
                 {
                     _SelectedSidebarItem = value;
-                    NotifyPropertyChanged("SelectedSidebarItem");
+                    NotifyPropertyChanged(nameof(SelectedSidebarItem));
                 }
             }
         }
@@ -54,7 +54,7 @@ namespace Files.Controls
                 if (value != _ShowUnpinItem)
                 {
                     _ShowUnpinItem = value;
-                    NotifyPropertyChanged("ShowUnpinItem");
+                    NotifyPropertyChanged(nameof(ShowUnpinItem));
                 }
             }
         }
@@ -72,7 +72,7 @@ namespace Files.Controls
                 if (value != _ShowEmptyRecycleBin)
                 {
                     _ShowEmptyRecycleBin = value;
-                    NotifyPropertyChanged("ShowEmptyRecycleBin");
+                    NotifyPropertyChanged(nameof(ShowEmptyRecycleBin));
                 }
             }
         }
@@ -90,7 +90,7 @@ namespace Files.Controls
                 if (value != _RecycleBinHasItems)
                 {
                     _RecycleBinHasItems = value;
-                    NotifyPropertyChanged("RecycleBinHasItems");
+                    NotifyPropertyChanged(nameof(RecycleBinHasItems));
                 }
             }
         }

--- a/Files/UserControls/Widgets/RecentFiles.xaml.cs
+++ b/Files/UserControls/Widgets/RecentFiles.xaml.cs
@@ -254,7 +254,7 @@ namespace Files
                 if (value != visibility)
                 {
                     visibility = value;
-                    NotifyPropertyChanged("Visibility");
+                    NotifyPropertyChanged(nameof(Visibility));
                 }
             }
         }

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -116,7 +116,7 @@ namespace Files.Filesystem
                 _customPath = null;
             }
 
-            NotifyPropertyChanged("WorkingDirectory");
+            NotifyPropertyChanged(nameof(WorkingDirectory));
         }
 
         public static async Task<StorageFolder> GetFolderFromPathAsync(string value)
@@ -153,24 +153,24 @@ namespace Files.Filesystem
                 if (value != _IsFolderEmptyTextDisplayed)
                 {
                     _IsFolderEmptyTextDisplayed = value;
-                    NotifyPropertyChanged("IsFolderEmptyTextDisplayed");
+                    NotifyPropertyChanged(nameof(IsFolderEmptyTextDisplayed));
                 }
             }
         }
 
         public void UpdateSortOptionStatus()
         {
-            NotifyPropertyChanged("IsSortedByName");
-            NotifyPropertyChanged("IsSortedByDate");
-            NotifyPropertyChanged("IsSortedByType");
-            NotifyPropertyChanged("IsSortedBySize");
+            NotifyPropertyChanged(nameof(IsSortedByName));
+            NotifyPropertyChanged(nameof(IsSortedByDate));
+            NotifyPropertyChanged(nameof(IsSortedByType));
+            NotifyPropertyChanged(nameof(IsSortedBySize));
             OrderFiles();
         }
 
         public void UpdateSortDirectionStatus()
         {
-            NotifyPropertyChanged("IsSortedAscending");
-            NotifyPropertyChanged("IsSortedDescending");
+            NotifyPropertyChanged(nameof(IsSortedAscending));
+            NotifyPropertyChanged(nameof(IsSortedDescending));
             OrderFiles();
         }
 
@@ -182,7 +182,7 @@ namespace Files.Filesystem
                 if (value)
                 {
                     AppSettings.DirectorySortOption = SortOption.Name;
-                    NotifyPropertyChanged("IsSortedByName");
+                    NotifyPropertyChanged(nameof(IsSortedByName));
                 }
             }
         }
@@ -195,7 +195,7 @@ namespace Files.Filesystem
                 if (value)
                 {
                     AppSettings.DirectorySortOption = SortOption.DateModified;
-                    NotifyPropertyChanged("IsSortedByDate");
+                    NotifyPropertyChanged(nameof(IsSortedByDate));
                 }
             }
         }
@@ -208,7 +208,7 @@ namespace Files.Filesystem
                 if (value)
                 {
                     AppSettings.DirectorySortOption = SortOption.FileType;
-                    NotifyPropertyChanged("IsSortedByType");
+                    NotifyPropertyChanged(nameof(IsSortedByType));
                 }
             }
         }
@@ -221,7 +221,7 @@ namespace Files.Filesystem
                 if (value)
                 {
                     AppSettings.DirectorySortOption = SortOption.Size;
-                    NotifyPropertyChanged("IsSortedBySize");
+                    NotifyPropertyChanged(nameof(IsSortedBySize));
                 }
             }
         }
@@ -232,8 +232,8 @@ namespace Files.Filesystem
             set
             {
                 AppSettings.DirectorySortDirection = value ? SortDirection.Ascending : SortDirection.Descending;
-                NotifyPropertyChanged("IsSortedAscending");
-                NotifyPropertyChanged("IsSortedDescending");
+                NotifyPropertyChanged(nameof(IsSortedAscending));
+                NotifyPropertyChanged(nameof(IsSortedDescending));
             }
         }
 
@@ -243,8 +243,8 @@ namespace Files.Filesystem
             set
             {
                 AppSettings.DirectorySortDirection = value ? SortDirection.Descending : SortDirection.Ascending;
-                NotifyPropertyChanged("IsSortedAscending");
-                NotifyPropertyChanged("IsSortedDescending");
+                NotifyPropertyChanged(nameof(IsSortedAscending));
+                NotifyPropertyChanged(nameof(IsSortedDescending));
             }
         }
 
@@ -447,7 +447,7 @@ namespace Files.Filesystem
                 if (_isLoadingItems != value)
                 {
                     _isLoadingItems = value;
-                    NotifyPropertyChanged("IsLoadingItems");
+                    NotifyPropertyChanged(nameof(IsLoadingItems));
                 }
             }
         }

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -48,7 +48,7 @@ namespace Files.Views
             set
             {
                 _SelectedTabItem = value;
-                NotifyPropertyChanged("SelectedTabItem");
+                NotifyPropertyChanged(nameof(SelectedTabItem));
             }
         }
 


### PR DESCRIPTION
Issue #1729 Code Improvement
String property names are now replaced with nameof()