### PR TITLE
replaced hardcoded property names with nameof()

### DIFF
--- a/Files/View Models/CurrentInstanceViewModel.cs
+++ b/Files/View Models/CurrentInstanceViewModel.cs
@@ -13,9 +13,9 @@ namespace Files.View_Models
             set
             {
                 Set(ref _IsPageTypeNotHome, value);
-                RaisePropertyChanged("IsCreateButtonEnabledInPage");
-                RaisePropertyChanged("CanCreateFileInPage");
-                RaisePropertyChanged("CanOpenTerminalInPage");
+                RaisePropertyChanged(nameof(IsCreateButtonEnabledInPage));
+                RaisePropertyChanged(nameof(CanCreateFileInPage));
+                RaisePropertyChanged(nameof(CanOpenTerminalInPage));
             }
         }
 
@@ -27,9 +27,9 @@ namespace Files.View_Models
             set
             {
                 Set(ref _IsPageTypeMtpDevice, value);
-                RaisePropertyChanged("IsCreateButtonEnabledInPage");
-                RaisePropertyChanged("CanCreateFileInPage");
-                RaisePropertyChanged("CanOpenTerminalInPage");
+                RaisePropertyChanged(nameof(IsCreateButtonEnabledInPage));
+                RaisePropertyChanged(nameof(CanCreateFileInPage));
+                RaisePropertyChanged(nameof(CanOpenTerminalInPage));
             }
         }
 
@@ -41,9 +41,9 @@ namespace Files.View_Models
             set
             {
                 Set(ref _IsPageTypeRecycleBin, value);
-                RaisePropertyChanged("IsCreateButtonEnabledInPage");
-                RaisePropertyChanged("CanCreateFileInPage");
-                RaisePropertyChanged("CanOpenTerminalInPage");
+                RaisePropertyChanged(nameof(IsCreateButtonEnabledInPage));
+                RaisePropertyChanged(nameof(CanCreateFileInPage));
+                RaisePropertyChanged(nameof(CanOpenTerminalInPage));
             }
         }
 


### PR DESCRIPTION
Fixes #1729 
This is just an addition to the PR from @d2dyno1.
This class was probably forgotten because `RaisePropertyChanged` is used instead of `NotifyPropertyChanged`.
But we should use nameof() wherever possible