### PR TITLE
Fixed an issue loading recent items on the home page

### DIFF
--- a/Files/UserControls/Widgets/RecentFiles.xaml.cs
+++ b/Files/UserControls/Widgets/RecentFiles.xaml.cs
@@ -110,12 +110,17 @@ namespace Files
             Visibility ItemFileIconVis;
             if (item.IsOfType(StorageItemTypes.File))
             {
-                using (var inputStream = await ((StorageFile)item).OpenReadAsync())
-                using (var classicStream = inputStream.AsStreamForRead())
-                using (var streamReader = new StreamReader(classicStream))
+                // Try to read the file to check if still exists
+                // This is only needed to remove files opened from a disconnected android/MTP phone
+                if (string.IsNullOrEmpty(item.Path)) // This indicates that the file was open from an MTP device
                 {
-                    // Try to read the file to check if still exists
-                    streamReader.Peek();
+                    using (var inputStream = await ((StorageFile)item).OpenReadAsync())
+                    using (var classicStream = inputStream.AsStreamForRead())
+                    using (var streamReader = new StreamReader(classicStream))
+                    {
+                        // NB: this might trigger the download of the file from OneDrive
+                        streamReader.Peek();
+                    }
                 }
 
                 ItemName = item.Name;

--- a/Files/UserControls/Widgets/RecentFiles.xaml.cs
+++ b/Files/UserControls/Widgets/RecentFiles.xaml.cs
@@ -77,19 +77,16 @@ namespace Files
                     IStorageItem item = await mostRecentlyUsed.GetItemAsync(mruToken);
                     await AddItemToRecentList(item, entry);
                 }
-                catch (FileNotFoundException)
-                {
-                    mostRecentlyUsed.Remove(mruToken);
-                }
-                catch (ArgumentException)
-                {
-                    mostRecentlyUsed.Remove(mruToken);
-                }
                 catch (UnauthorizedAccessException)
                 {
                     // Skip item until consent is provided
                 }
-                catch (COMException ex)
+                catch (Exception ex) when (
+                    ex is COMException
+                    || ex is FileNotFoundException
+                    || ex is ArgumentException
+                    || (uint)ex.HResult == 0x8007016A // The cloud file provider is not running
+                    || (uint)ex.HResult == 0x8000000A) // The data necessary to complete this operation is not yet available
                 {
                     mostRecentlyUsed.Remove(mruToken);
                     System.Diagnostics.Debug.WriteLine(ex);


### PR DESCRIPTION
Fixes #1645

Loading recent files list may cause files to be downloaded from OneDrive.
Trying to read a file with `streamReader.Peek();` will trigger the download of the file if such file is in OneDrive and marked "online-only". 

That piece of code was added to remove files opened from a disconnected android/MTP phone, so this PR adds a check to only call `streamReader.Peek();` if the file was on a MTP phone. This will avoid to risk downloading the file.
This PR also adds handling for a couple more exceptions in `PopulateRecentsList()` that were seen in crash reports on AppCenter (at this point it might make sense to just `catch (Exception) {`..