### PR TITLE
Show consent dialog for broadFileSystemAccess

### DIFF
--- a/Files/Filesystem/Drives.cs
+++ b/Files/Filesystem/Drives.cs
@@ -1,11 +1,13 @@
 using Files.View_Models;
 using Files.Views;
+using GalaSoft.MvvmLight;
 using NLog;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
 using Windows.Devices.Enumeration;
@@ -15,37 +17,46 @@ using Windows.UI.Core;
 
 namespace Files.Filesystem
 {
-    public class DrivesManager
+    public class DrivesManager : ObservableObject
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
         public SettingsViewModel AppSettings => App.AppSettings;
         public IList<DriveItem> Drives { get; } = new List<DriveItem>();
-        public bool ShowUserConsentOnInit { get; set; } = false;
+        private bool _ShowUserConsentOnInit = false;
+        public bool ShowUserConsentOnInit
+        {
+            get => _ShowUserConsentOnInit;
+            set => Set(ref _ShowUserConsentOnInit, value);
+        }
         private DeviceWatcher _deviceWatcher;
 
         public DrivesManager()
         {
-            Task findDrivesTask = null;
+            EnumerateDrives();
+        }
+
+        private async void EnumerateDrives()
+        {
             try
             {
-                findDrivesTask = GetDrives(Drives);
+                await GetDrives(Drives);
+                GetVirtualDrivesList(Drives);
+                StartDeviceWatcher();
             }
             catch (AggregateException)
             {
                 ShowUserConsentOnInit = true;
-            }
+            };
+        }
 
-            findDrivesTask.ContinueWith((x) =>
-            {
-                GetVirtualDrivesList(Drives);
-
-                _deviceWatcher = DeviceInformation.CreateWatcher(StorageDevice.GetDeviceSelector());
-                _deviceWatcher.Added += DeviceAdded;
-                _deviceWatcher.Removed += DeviceRemoved;
-                _deviceWatcher.Updated += DeviceUpdated;
-                _deviceWatcher.EnumerationCompleted += DeviceWatcher_EnumerationCompleted;
-                _deviceWatcher.Start();
-            });
+        private void StartDeviceWatcher()
+        {
+            _deviceWatcher = DeviceInformation.CreateWatcher(StorageDevice.GetDeviceSelector());
+            _deviceWatcher.Added += DeviceAdded;
+            _deviceWatcher.Removed += DeviceRemoved;
+            _deviceWatcher.Updated += DeviceUpdated;
+            _deviceWatcher.EnumerationCompleted += DeviceWatcher_EnumerationCompleted;
+            _deviceWatcher.Start();
         }
 
         private async void DeviceWatcher_EnumerationCompleted(DeviceWatcher sender, object args)
@@ -337,9 +348,12 @@ namespace Files.Filesystem
 
         public void Dispose()
         {
-            if (_deviceWatcher.Status == DeviceWatcherStatus.Started || _deviceWatcher.Status == DeviceWatcherStatus.EnumerationCompleted)
+            if (_deviceWatcher != null)
             {
-                _deviceWatcher.Stop();
+                if (_deviceWatcher.Status == DeviceWatcherStatus.Started || _deviceWatcher.Status == DeviceWatcherStatus.EnumerationCompleted)
+                {
+                    _deviceWatcher.Stop();
+                }
             }
         }
     }

--- a/Files/View Models/SettingsViewModel.cs
+++ b/Files/View Models/SettingsViewModel.cs
@@ -636,7 +636,7 @@ namespace Files.View_Models
 
         public void Dispose()
         {
-            DrivesManager.Dispose();
+            DrivesManager?.Dispose();
         }
 
         public bool Set<TValue>(TValue value, [CallerMemberName] string propertyName = null)

--- a/Files/Views/ModernShellPage.xaml.cs
+++ b/Files/Views/ModernShellPage.xaml.cs
@@ -29,11 +29,8 @@ namespace Files.Views.Pages
         public ModernShellPage()
         {
             this.InitializeComponent();
-            if (AppSettings.DrivesManager.ShowUserConsentOnInit)
-            {
-                AppSettings.DrivesManager.ShowUserConsentOnInit = false;
-                DisplayFilesystemConsentDialog();
-            }
+            AppSettings.DrivesManager.PropertyChanged += DrivesManager_PropertyChanged;
+            DisplayFilesystemConsentDialog();
 
             var flowDirectionSetting = ResourceContext.GetForCurrentView().QualifierValues["LayoutDirection"];
 
@@ -46,6 +43,14 @@ namespace Files.Views.Pages
             App.CurrentInstance.NavigationToolbar.PathControlDisplayText = ResourceController.GetTranslation("NewTab");
             App.CurrentInstance.NavigationToolbar.CanGoBack = false;
             App.CurrentInstance.NavigationToolbar.CanGoForward = false;
+        }
+
+        private void DrivesManager_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == "ShowUserConsentOnInit")
+            {
+                DisplayFilesystemConsentDialog();
+            }
         }
 
         Type IShellPage.CurrentPageType => ItemDisplayFrame.SourcePageType;
@@ -83,8 +88,12 @@ namespace Files.Views.Pages
 
         private async void DisplayFilesystemConsentDialog()
         {
-            var consentDialogDisplay = new ConsentDialog();
-            await consentDialogDisplay.ShowAsync(ContentDialogPlacement.Popup);
+            if (AppSettings.DrivesManager.ShowUserConsentOnInit)
+            {
+                AppSettings.DrivesManager.ShowUserConsentOnInit = false;
+                var consentDialogDisplay = new ConsentDialog();
+                await consentDialogDisplay.ShowAsync(ContentDialogPlacement.Popup);
+            }
         }
 
         private string NavParams = null;


### PR DESCRIPTION
Fixes #1747

This PR makes sure that the consent dialog for the broadFileSystemAccess permission is shown on app start.