### PR TITLE
Fixed closing last tab causes an exception with continue where you left off

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -415,7 +415,7 @@ namespace Files
 
         private void SaveSessionTabs() // Enumerates through all tabs and gets the Path property and saves it to AppSettings.LastSessionPages
         {
-            AppSettings.LastSessionPages = MainPage.AppInstances.DefaultIfEmpty().Select(x => x != null ? x.Path : ResourceController.GetTranslation("NewTab")).ToArray();
+            AppSettings.LastSessionPages = MainPage.AppInstances.DefaultIfEmpty().Select(tab => tab != null ? tab.Path ?? ResourceController.GetTranslation("NewTab") : ResourceController.GetTranslation("NewTab")).ToArray();
         }
 
         // Occurs when an exception is not handled on the UI thread.


### PR DESCRIPTION
Fixes #1799 
Fixed an issue where an exception would occur when closing tab with continue where you left off