### PR TITLE
Fixed an issue where external devices cannot be removed while app is opened

### DIFF
--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -1129,6 +1129,8 @@ namespace Files.Filesystem
 
             IntPtr hFile = FindFirstFileExFromApp(fileOrFolderPath, findInfoLevel, out WIN32_FIND_DATA findData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero,
                                                   additionalFlags);
+            FindClose(hFile);
+
             if ((findData.dwFileAttributes & 0x10) > 0) // FILE_ATTRIBUTE_DIRECTORY
             {
                 AddFolder(findData, Directory.GetParent(fileOrFolderPath).FullName);
@@ -1556,9 +1558,11 @@ namespace Files.Filesystem
             FINDEX_INFO_LEVELS findInfoLevel = FINDEX_INFO_LEVELS.FindExInfoBasic;
             int additionalFlags = FIND_FIRST_EX_LARGE_FETCH;
 
-            IntPtr hFile = FindFirstFileExFromApp(targetPath + "\\*.*", findInfoLevel, out WIN32_FIND_DATA findChildData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, additionalFlags);
-            FindNextFile(hFile, out findChildData);
-            return FindNextFile(hFile, out findChildData);
+            IntPtr hFile = FindFirstFileExFromApp(targetPath + "\\*.*", findInfoLevel, out WIN32_FIND_DATA _, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, additionalFlags);
+            FindNextFile(hFile, out _);
+            var result = FindNextFile(hFile, out _);
+            FindClose(hFile);
+            return result;
         }
     }
 }

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -80,7 +80,7 @@ namespace Files.Views
                 foreach (var removedTab in e.OldItems)
                 {
                     // Cleanup resources for the closed tab
-                    ((((removedTab as TabItem).Content as Grid).Children[0] as Frame).Content as IShellPage).FilesystemViewModel?.Dispose();
+                    ((((removedTab as TabItem).Content as Grid).Children[0] as Frame).Content as IShellPage)?.FilesystemViewModel?.Dispose();
                 }
             }
         }

--- a/Files/Views/MainPage.xaml.cs
+++ b/Files/Views/MainPage.xaml.cs
@@ -69,6 +69,20 @@ namespace Files.Views
             }
 
             AllowDrop = true;
+
+            AppInstances.CollectionChanged += AppInstances_CollectionChanged;
+        }
+
+        private void AppInstances_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            if (e.OldItems != null)
+            {
+                foreach (var removedTab in e.OldItems)
+                {
+                    // Cleanup resources for the closed tab
+                    ((((removedTab as TabItem).Content as Grid).Children[0] as Frame).Content as IShellPage).FilesystemViewModel?.Dispose();
+                }
+            }
         }
 
         protected override async void OnNavigatedTo(NavigationEventArgs eventArgs)


### PR DESCRIPTION
Fix #1767

This PR allows to eject a connected USB drive without closing the app. It's sufficient to close the tab or navigate away.

Please check if you agree on how to detect when a tab was closed, I don't know much about how tabs are handled.
