### PR TITLE
Resume devicewatcher after suspending

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -83,6 +83,7 @@ namespace Files
         {
             // Need to reinitialize AppService when app is resuming
             InitializeAppServiceConnection();
+            AppSettings?.DrivesManager?.StartDeviceWatcher();
         }
 
         public static AppServiceConnection Connection;

--- a/Files/Filesystem/Drives.cs
+++ b/Files/Filesystem/Drives.cs
@@ -50,8 +50,9 @@ namespace Files.Filesystem
             };
         }
 
-        private void StartDeviceWatcher()
+        public void StartDeviceWatcher()
         {
+            this.Dispose();
             _deviceWatcher = DeviceInformation.CreateWatcher(StorageDevice.GetDeviceSelector());
             _deviceWatcher.Added += DeviceAdded;
             _deviceWatcher.Removed += DeviceRemoved;


### PR DESCRIPTION
Fixes #1817

The device watcher was stopped in OnSuspending but not resumed when the app was restored.
