### PR TITLE
Fixed a crash that would sometimes occur when cutting an item

### DIFF
--- a/Files/Filesystem/ListedItem.cs
+++ b/Files/Filesystem/ListedItem.cs
@@ -46,6 +46,14 @@ namespace Files.Filesystem
             set => SetProperty(ref _LoadUnknownTypeGlyph, value);
         }
 
+        private bool _IsDimmed;
+
+        public bool IsDimmed
+        {
+            get => _IsDimmed;
+            set => SetProperty(ref _IsDimmed, value);
+        }
+
         private CloudDriveSyncStatusUI _SyncStatusUI;
 
         public CloudDriveSyncStatusUI SyncStatusUI

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml
@@ -21,6 +21,9 @@
 
     <local:BaseLayout.Resources>
         <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
+        <converters:BoolToObjectConverter x:Key="BoolToOpacityConverter"
+                                          FalseValue="1"
+                                          TrueValue="0.4" />
 
         <MenuFlyout x:Key="BaseLayoutContextFlyout">
             <MenuFlyoutSubItem
@@ -614,6 +617,7 @@
                             <Grid
                                 x:Name="Icon"
                                 EffectiveViewportChanged="Icon_EffectiveViewportChanged"
+                                Opacity="{x:Bind IsDimmed, Converter={StaticResource BoolToOpacityConverter}, Mode=OneWay}"
                                 ToolTipService.ToolTip="{x:Bind FolderTooltipText}">
                                 <Rectangle
                                     x:Name="CutIndicator"

--- a/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GenericFileBrowser.xaml.cs
@@ -175,17 +175,13 @@ namespace Files
 
             foreach (ListedItem listedItem in items)
             {
-                FrameworkElement element = AllView.Columns[0].GetCellContent(listedItem);
-                if (element != null)
-                {
-                    element.Opacity = 1;
-                }
+                listedItem.IsDimmed = false;
             }
         }
 
         public override void SetItemOpacity(ListedItem item)
         {
-            AllView.Columns[0].GetCellContent(item).Opacity = 0.4;
+            item.IsDimmed = true;
         }
 
         private async void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml
@@ -17,6 +17,9 @@
     mc:Ignorable="d">
     <local:BaseLayout.Resources>
         <converters:BoolNegationConverter x:Key="BoolNegationConverter" />
+        <converters:BoolToObjectConverter x:Key="BoolToOpacityConverter"
+                                          FalseValue="1"
+                                          TrueValue="0.4" />
 
         <MenuFlyout x:Key="BaseLayoutContextFlyout">
             <MenuFlyoutSubItem
@@ -473,6 +476,7 @@
                     Grid.Row="0"
                     Width="{x:Bind local:App.AppSettings.GridViewSize, Mode=OneWay}"
                     Height="{x:Bind local:App.AppSettings.GridViewSize, Mode=OneWay}"
+                    Opacity="{x:Bind IsDimmed, Converter={StaticResource BoolToOpacityConverter}, Mode=OneWay}"
                     Tag="ItemImage">
                     <Grid
                         x:Name="Picture"
@@ -614,6 +618,7 @@
                     Grid.Column="1"
                     Height="Auto"
                     MinHeight="100"
+                    Opacity="{x:Bind IsDimmed, Converter={StaticResource BoolToOpacityConverter}, Mode=OneWay}"
                     Tag="ItemImage">
                     <Grid
                         x:Name="Picture"

--- a/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
+++ b/Files/Views/LayoutModes/GridViewBrowser.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using Files.Filesystem;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Windows.System;
@@ -194,27 +195,21 @@ namespace Files
 
         public override void ResetItemOpacity()
         {
-            foreach (ListedItem listedItem in FileList.Items)
+            IEnumerable items = (IEnumerable)FileList.ItemsSource;
+            if (items == null)
             {
-                List<Grid> itemContentGrids = new List<Grid>();
-                GridViewItem gridViewItem = FileList.ContainerFromItem(listedItem) as GridViewItem;
-                if (gridViewItem == null)
-                {
-                    return;
-                }
-                Interaction.FindChildren<Grid>(itemContentGrids, gridViewItem);
-                var imageOfItem = itemContentGrids.Find(x => x.Tag?.ToString() == "ItemImage");
-                imageOfItem.Opacity = 1;
+                return;
+            }
+
+            foreach (ListedItem listedItem in items)
+            {
+                listedItem.IsDimmed = false;
             }
         }
 
         public override void SetItemOpacity(ListedItem item)
         {
-            GridViewItem itemToDimForCut = (GridViewItem)FileList.ContainerFromItem(item);
-            List<Grid> itemContentGrids = new List<Grid>();
-            Interaction.FindChildren(itemContentGrids, itemToDimForCut);
-            var imageOfItem = itemContentGrids.Find(x => x.Tag?.ToString() == "ItemImage");
-            imageOfItem.Opacity = 0.4;
+            item.IsDimmed = true;
         }
 
         private void RenameTextBox_KeyDown(object sender, KeyRoutedEventArgs e)


### PR DESCRIPTION
Fixes #1816, fixes #1400

GridView and ListView virtualize items so for example `ContainerFromItem(...)` returns null for items outside the rendered range and this was causing the reported exception.
This PR adds a "IsDimmed" property to ListedItem and setting the opacity is now done through binding instead of directly accessing the UI item.
