### PR TITLE
Fix duplicate removable drives in sidebar

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -79,7 +79,7 @@ namespace Files
         {
             // Need to reinitialize AppService when app is resuming
             InitializeAppServiceConnection();
-            AppSettings?.DrivesManager?.StartDeviceWatcher();
+            AppSettings?.DrivesManager?.ResumeDeviceWatcher();
         }
 
         public static AppServiceConnection Connection;


### PR DESCRIPTION
Fix #1829

Fix removable drives appearing twice in the sidebar, bug introduced by #1819

Explanation: the same drive was being added in both `DeviceAdded()` and `GetDrives()` functions. This PR adds a flag that indicates if `GetDrives()` is running.