### PR TITLE
Fixed an issue where opening the properties window would sometimes crash the app on 1903/1909

### DIFF
--- a/Files/Views/Pages/Properties.xaml.cs
+++ b/Files/Views/Pages/Properties.xaml.cs
@@ -91,7 +91,7 @@ namespace Files
                     TintColor = AppSettings.AcrylicTheme.TintColor,
                     TintOpacity = AppSettings.AcrylicTheme.TintOpacity,
                 };
-                if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
+                if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 9))
                 {
                     backgroundBrush.TintLuminosityOpacity = 0.9;
                 }


### PR DESCRIPTION
Fix #1771

Do not set the AcrylicBrush's TintLuminosityOpacity property on 1903/1909 as it makes the app crash (only in Release mode).
Funny since TintLuminosityOpacity should be supported in 1903.
@Jaiganeshkumaran could you test this and confirm?
