### PR TITLE
Fixed a crash that would sometimes occur when selecting some options on the right click context menu

### DIFF
--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -334,7 +334,7 @@ namespace FilesFullTrust
         {
             var knownItems = new List<string>() {
                 "opennew", "openas", "opencontaining", "opennewprocess",
-                "runas", "runasuser", "pintohome",
+                "runas", "runasuser", "pintohome", "PinToStartScreen",
                 "cut", "copy", "delete", "properties", "link",
                 "WSL", "Windows.ModernShare", "Windows.Share", "setdesktopwallpaper",
                 Win32API.ExtractStringFromDLL("shell32.dll", 30312), // SendTo menu

--- a/Files.Launcher/Win32API_ContextMenu.cs
+++ b/Files.Launcher/Win32API_ContextMenu.cs
@@ -147,9 +147,10 @@ namespace FilesFullTrust
                     pici.cbSize = (uint)Marshal.SizeOf(pici);
                     cMenu.InvokeCommand(pici);
                 }
-                catch (COMException ex)
+                catch (Exception ex) when (
+                    ex is COMException
+                    || ex is UnauthorizedAccessException)
                 {
-                    // Usually it's "invalid window handle"
                     Debug.WriteLine(ex);
                 }
             }
@@ -165,9 +166,10 @@ namespace FilesFullTrust
                     pici.cbSize = (uint)Marshal.SizeOf(pici);
                     cMenu.InvokeCommand(pici);
                 }
-                catch (COMException ex)
+                catch (Exception ex) when (
+                    ex is COMException
+                    || ex is UnauthorizedAccessException)
                 {
-                    // Usually it's "invalid window handle"
                     Debug.WriteLine(ex);
                 }
             }


### PR DESCRIPTION
Fixes #1869

This PR hides the "pin to start" context menu option which is not working. Also it avoids fulltrust process crash in case the same happens with other menu items.