### PR TITLE
Hide windows explorer's paste command from context menu

### DIFF
--- a/Files.Launcher/Program.cs
+++ b/Files.Launcher/Program.cs
@@ -340,7 +340,7 @@ namespace FilesFullTrust
             var knownItems = new List<string>() {
                 "opennew", "openas", "opencontaining", "opennewprocess",
                 "runas", "runasuser", "pintohome", "PinToStartScreen",
-                "cut", "copy", "delete", "properties", "link",
+                "cut", "copy", "paste", "delete", "properties", "link",
                 "WSL", "Windows.ModernShare", "Windows.Share", "setdesktopwallpaper",
                 Win32API.ExtractStringFromDLL("shell32.dll", 30312), // SendTo menu
                 Win32API.ExtractStringFromDLL("shell32.dll", 34593), // Add to collection


### PR DESCRIPTION
Fixes #1942